### PR TITLE
fix: corrige error al asignar líder en colonia

### DIFF
--- a/app/colonias/repositories/colonia_repository.py
+++ b/app/colonias/repositories/colonia_repository.py
@@ -5,6 +5,7 @@ relacionadas con colonias colombianas, utilizando sesiones SQLAlchemy
 como capa de persistencia.
 """
 
+from app.usuarios.models.usuario import Usuario
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.colonias.models.colonia_model import Colonia
@@ -57,13 +58,15 @@ class ColoniaRepository:
         return resultado.scalars().first()
     
     async def obtener_colonia_por_id(self, colonia_codigo: int) -> Colonia | None:
-        sentencia = select(Colonia).filter(Colonia.codigo == colonia_codigo)
+        sentencia = select(Colonia).filter(Colonia.co_codigo == colonia_codigo)
         resultado = await self.db.execute(sentencia)
         return resultado.scalars().first()
 
     async def establecer_lider_colonia(self, colonia_codigo: int, lider_id: int) -> Colonia:
         colonia = await self.obtener_colonia_por_id(colonia_codigo)
         colonia.lider = lider_id
+        usuario = await self.db.get(Usuario, lider_id)
+        usuario.ro_codigo = 2 #Revisar si es necesario cambiar el rol del usuario a lider
         await self.db.commit()
         await self.db.refresh(colonia)
         return colonia

--- a/app/colonias/repositories/solicitud_colonia_repository.py
+++ b/app/colonias/repositories/solicitud_colonia_repository.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from typing import Optional
+from app.usuarios.models.usuario import Usuario
 from sqlalchemy.orm import joinedload
 from app.colonias.excepciones.excepciones import SolicitudEstadoInvalido, SolicitudNoEncontrada
 from app.colonias.models.solicitud_colonia import SolicitudColonia, EstadoSolicitud
@@ -55,6 +56,8 @@ class SolicitudColoniaRepository:
             raise SolicitudEstadoInvalido(f"Solo se pueden aceptar solicitudes pendientes. Solicitud {codigo} está en estado {solicitud.so_estado.value}.")
         
         solicitud.so_estado = EstadoSolicitud.aceptada
+        usuario = await self.db.get(Usuario, solicitud.us_codigo)
+        usuario.co_codigo = solicitud.co_codigo
         await self.db.commit()
         await self.db.refresh(solicitud)
 


### PR DESCRIPTION
## Descripción del Cambio
Se corrige un error al asignar líder en una colonia, donde la API retornaba un error 500 debido a una validación incorrecta de datos.

## Issue relacionado
Closes #17

## ¿Qué se hizo?
- Se corrigió los nombres de los atributos
- Se relaciono un usuario con su colonia al aceptar una solicitud
- Se cambia el rol de un usuario al asignarlo como lider

## ¿Cómo probar este cambio?

### Backend:
1. Levantar el proyecto con Docker
2. Ir a Swagger (/docs)
3. Ejecutar el endpoint de asignar líder con datos válidos