### PR TITLE
fix: correción JSON endpoint Listar Parentescos

### DIFF
--- a/app/usuarios/docs/listar_parentescos_doc.py
+++ b/app/usuarios/docs/listar_parentescos_doc.py
@@ -5,12 +5,13 @@ las relaciones de parentesco asociadas a un usuario específico, ya sea como sol
 Se incluyen detalles sobre el acceso, los parámetros requeridos y las posibles respuestas del endpoint.
 """
 
-from app.usuarios.schemas.parentesco_esquemas import ParentescoRespuestaDetallada
+from app.usuarios.schemas.parentesco_esquemas import ParentescoLista
 from fastapi import Body
 from typing import Annotated
 
 listar_parentescos_docs = dict(
     summary="Listar parentescos de un usuario",
+    response_model=list[ParentescoLista],
     description="""
 Obtiene una lista de todas 
 las relaciones de parentesco asociadas a un usuario específico, ya sea como solicitante o destinatario.
@@ -25,14 +26,14 @@ las relaciones de parentesco asociadas a un usuario específico, ya sea como sol
                 "application/json": {
                     "example": [
                         {
-                            "codigo_parentesco": 1,
+                            "codigo": 1,
                             "codigo_solicitante": 1,
                             "codigo_destinatario": 2,
                             "tipo_parentesco": "hermano (a)",
                             "estado": "aceptada"
                         },
                         {
-                            "codigo_parentesco": 2,
+                            "codigo": 2,
                             "codigo_solicitante": 3,
                             "codigo_destinatario": 1,
                             "tipo_parentesco": "padre",

--- a/app/usuarios/models/parentesco.py
+++ b/app/usuarios/models/parentesco.py
@@ -32,24 +32,25 @@ class TipoParentesco(str, enum.Enum):
 class Parentesco(Base):
     __tablename__ = "parentesco"
 
-    pa_codigo: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    pa_fecha_creacion: Mapped[DateTime] = mapped_column(
+    codigo: Mapped[int] = mapped_column("pa_codigo", Integer, primary_key=True, autoincrement=True)
+    fecha_creacion: Mapped[DateTime] = mapped_column(
+        "pa_fecha_creacion",
         DateTime(timezone=True),
         server_default=func.now(),
         nullable=False,
     )
-    pa_estado: Mapped[EstadoSolicitudParentesco] = mapped_column(Enum(EstadoSolicitudParentesco), nullable=False, default=EstadoSolicitudParentesco.pendiente)
+    estado: Mapped[EstadoSolicitudParentesco] = mapped_column("pa_estado", Enum(EstadoSolicitudParentesco), nullable=False, default=EstadoSolicitudParentesco.pendiente)
 
-    us_codigo_solicitante: Mapped[int] = mapped_column(Integer, ForeignKey("usuario.us_codigo"), nullable=False)
-    us_codigo_destinatario: Mapped[int] = mapped_column(Integer, ForeignKey("usuario.us_codigo"), nullable=False)
+    codigo_solicitante: Mapped[int] = mapped_column("us_codigo_solicitante", Integer, ForeignKey("usuario.us_codigo"), nullable=False)
+    codigo_destinatario: Mapped[int] = mapped_column("us_codigo_destinatario", Integer, ForeignKey("usuario.us_codigo"), nullable=False)
 
-    pa_tipo_parentesco: Mapped[TipoParentesco] = mapped_column(Enum(TipoParentesco), nullable=False)
+    tipo_parentesco: Mapped[TipoParentesco] = mapped_column("pa_tipo_parentesco", Enum(TipoParentesco), nullable=False)
 
     # ─────────────────────────────────────────
     #  Relaciones
     # ─────────────────────────────────────────
-    solicitante: Mapped["Usuario"] = relationship("Usuario", foreign_keys=[us_codigo_solicitante])
-    destinatario: Mapped["Usuario"] = relationship("Usuario", foreign_keys=[us_codigo_destinatario])
+    solicitante: Mapped["Usuario"] = relationship("Usuario", foreign_keys=[codigo_solicitante])
+    destinatario: Mapped["Usuario"] = relationship("Usuario", foreign_keys=[codigo_destinatario])
 
     def __repr__(self) -> str:
         return f"Parentesco(id={self.pa_codigo!r}, pa_estado={self.pa_estado!r} us_codigo_solicitante={self.us_codigo_solicitante!r} us_codigo_destinatario={self.us_codigo_destinatario!r} tipo_parentesco={self.pa_tipo_parentesco!r})"

--- a/app/usuarios/repository/parentesco_repositorio.py
+++ b/app/usuarios/repository/parentesco_repositorio.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import select
 from app.usuarios.models.parentesco import Parentesco, EstadoSolicitudParentesco
-from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear
+from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoLista
 
 class ParentescoRepositorio:
 
@@ -15,9 +15,9 @@ class ParentescoRepositorio:
 
     async def solicitar_parentesco(self, parentesco_crear: ParentescoCrear) -> Parentesco:
         parentesco = Parentesco(
-            us_codigo_solicitante=parentesco_crear.codigo_solicitante,
-            us_codigo_destinatario=parentesco_crear.codigo_destinatario,
-            pa_tipo_parentesco=parentesco_crear.tipo_parentesco
+            codigo_solicitante=parentesco_crear.codigo_solicitante,
+            codigo_destinatario=parentesco_crear.codigo_destinatario,
+            tipo_parentesco=parentesco_crear.tipo_parentesco
         )
         self.db.add(parentesco)
         await self.db.commit()
@@ -28,9 +28,9 @@ class ParentescoRepositorio:
         """Verifica si ya existe una solicitud de parentesco entre dos usuarios."""
         result = await self.db.execute(
             select(Parentesco).where(
-                Parentesco.us_codigo_solicitante == codigo_solicitante,
-                Parentesco.us_codigo_destinatario == codigo_destinatario,
-                Parentesco.pa_estado == EstadoSolicitudParentesco.pendiente
+                Parentesco.codigo_solicitante == codigo_solicitante,
+                Parentesco.codigo_destinatario == codigo_destinatario,
+                Parentesco.estado == EstadoSolicitudParentesco.pendiente
             )
         )
         return result.scalar_one_or_none() is not None
@@ -39,18 +39,18 @@ class ParentescoRepositorio:
         """Verifica si ya existe una relacion de parentesco entre dos usuarios."""
         result = await self.db.execute(
             select(Parentesco).where(
-                Parentesco.us_codigo_solicitante == codigo_solicitante,
-                Parentesco.us_codigo_destinatario == codigo_destinatario,
-                Parentesco.pa_estado == EstadoSolicitudParentesco.aceptada   
+                Parentesco.codigo_solicitante == codigo_solicitante,
+                Parentesco.codigo_destinatario == codigo_destinatario,
+                Parentesco.estado == EstadoSolicitudParentesco.aceptada   
             )
         )
         return result.scalar_one_or_none() is not None
     
-    async def listar_parentescos_usuario(self, codigo_usuario: int) -> list[Parentesco]:
+    async def listar_parentescos_usuario(self, codigo_usuario: int) -> list[ParentescoLista]:
         """Lista todas las relaciones de parentesco de un usuario."""
         result = await self.db.execute(
             select(Parentesco).where(
-                (Parentesco.us_codigo_destinatario == codigo_usuario) | (Parentesco.us_codigo_solicitante == codigo_usuario),
+                (Parentesco.codigo_destinatario == codigo_usuario) | (Parentesco.codigo_solicitante == codigo_usuario),
             )
         )
         return result.scalars().all()

--- a/app/usuarios/schemas/parentesco_esquemas.py
+++ b/app/usuarios/schemas/parentesco_esquemas.py
@@ -34,3 +34,13 @@ class ParentescoRespuestaDetallada(BaseModel):
     solicitante: UsuarioResumen
     destinatario: UsuarioResumen
     model_config = {"from_attributes": True, "populate_by_name": True}
+
+
+class ParentescoLista(BaseModel):
+    codigo: int
+    codigo_solicitante: int
+    codigo_destinatario: int
+    tipo_parentesco: TipoParentesco
+    estado: EstadoSolicitudParentesco
+
+    model_config = {"from_attributes": True}


### PR DESCRIPTION
## Descripción del Cambio
Se corrigió la respuesta del endpoint `GET /{codigo_usuario}/parentescos` que retornaba 
campos adicionales (`fecha_creacion`) no contemplados en el schema de respuesta esperado.

**Causa:** El endpoint no tenía definido un `response_model`, por lo que FastAPI retornaba 
el objeto ORM completo en lugar de serializar con el schema correcto.

**Solución:** Se agregó `response_model=list[ParentescoLista]` en el decorador del endpoint.

## ID de la Historia de Usuario
- **HU:** [el código de tu tarea/historia]

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [ ] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%?
- [x] ¿Las validaciones de negocio (Documento > 0, Celular 10 dígitos, etc.) están implementadas?

## ¿Cómo probar este cambio?
**Backend:**
1. Levantar con Docker.
2. Probar en Swagger (`/docs`) con estos datos:
   - Endpoint: `GET /{codigo_usuario}/parentescos`
   - `codigo_usuario`: 1
3. Verificar que la respuesta contenga solo los campos: 
   `codigo`, `codigo_solicitante`, `codigo_destinatario`, `tipo_parentesco`, `estado`
4. Verificar que **NO** aparezca `fecha_creacion` en la respuesta.
