### PR TITLE
feat(2GR-2): Inscribirse a un retorno

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -36,7 +36,6 @@ async def lifespan(app: FastAPI):
     # Startup
     logger.info("Starting %s v%s...", settings.APP_NAME, settings.APP_VERSION)
     await check_db_connection()
-    await create_tables()
     print(">>> lifespan ejecutándose")
     
     # Ejecutar seed de roles automáticamente al iniciar la app

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from app.usuarios.models.usuario import Usuario
 from app.usuarios.models.parentesco import Parentesco
 from app.retornos.api.v1.endpoints.retorno_router import router as retornos_router
 from app.colonias.models.solicitud_colonia import SolicitudColonia
+from app.retornos.modelos.registro_retorno_modelo import RegistroRetorno
 from scripts.seed_roles import seed_roles
 import app.core.scheduler as scheduler
 
@@ -35,6 +36,7 @@ async def lifespan(app: FastAPI):
     # Startup
     logger.info("Starting %s v%s...", settings.APP_NAME, settings.APP_VERSION)
     await check_db_connection()
+    await create_tables()
     print(">>> lifespan ejecutándose")
     
     # Ejecutar seed de roles automáticamente al iniciar la app
@@ -84,7 +86,7 @@ from app.retornos.api.v1.endpoints.retorno_router import router as retornos_rout
 from app.usuarios.api.v1.usuario_router import router as usuario_router
 app.include_router(colonia_router, prefix="/api/v1")
 app.include_router(usuario_router, prefix="/api/v1")
-app.include_router(retornos_router)
+app.include_router(retornos_router, prefix="/api/v1")
 
 # ─────────────────────────────────────────
 #  Core endpoints

--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -4,6 +4,12 @@ Expone operaciones de creación y consulta bajo el prefijo /retornos,
 con documentación Swagger integrada.
 """
 
+from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoRespuesta
+from app.retornos.repositorios.registro_retorno_repositorio import RegistroRetornoRepositorio
+from app.retornos.repositorios.retorno_repositorio import RetornoRepository
+from app.retornos.servicios.registro_retorno_servicio import RegistroRetornoServicio
+from app.usuarios.repository.usuario_repositorio import UsuarioRepositorio
+from app.usuarios.services.usuario_servicio import UsuarioServicio
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
@@ -14,6 +20,17 @@ router = APIRouter(
     prefix="/retornos",
     tags=["Retornos"],
 )
+
+def obtener_registro_retorno_servicio(db: AsyncSession = Depends(get_db)) -> RegistroRetornoServicio:
+    repositorio = RegistroRetornoRepositorio(db)
+    retorno_repositorio = RetornoRepository(db)
+    usuario_servicio = UsuarioServicio(UsuarioRepositorio(db), None)
+    
+    return RegistroRetornoServicio(
+        repositorio,
+        retorno_repositorio,
+        usuario_servicio
+    )
 
 
 @router.post(
@@ -61,3 +78,26 @@ async def listar_retornos(db: AsyncSession = Depends(get_db)):
 async def obtener_retorno(codigo: int, db: AsyncSession = Depends(get_db)):
     service = RetornoService(db)
     return await service.obtener_retorno(codigo)
+
+@router.post(
+    "/registro",
+    response_model=RegistroRetornoRespuesta,
+    status_code=status.HTTP_201_CREATED,
+    summary="Registrar participación en un retorno",
+    description=(
+        "Crea un nuevo registro de participación para un usuario en un retorno específico. "
+        "Cada usuario solo puede registrar una participación por retorno."
+    ),
+    responses={
+        409: {
+            "description": "El usuario ya tiene un registro para este retorno.",
+            "content": {"application/json": {"example": {"detail": "El usuario ya tiene un registro para este retorno."}}},
+        },
+        422: {
+            "description": "Datos de entrada inválidos.",
+            "content": {"application/json": {"example": {"detail": "Datos de entrada inválidos."}}},
+        },
+    },
+)
+async def inscribir_usuario_en_retorno(registro: RegistroRetornoCrear, servicio: RegistroRetornoServicio = Depends(obtener_registro_retorno_servicio)):
+    return await servicio.crear_registro_retorno(registro)

--- a/app/retornos/esquemas/registro_retorno_esquema.py
+++ b/app/retornos/esquemas/registro_retorno_esquema.py
@@ -1,0 +1,22 @@
+
+from pydantic import BaseModel, Field
+import datetime
+
+class RegistroRetornoCrear(BaseModel):
+    usuario: int
+    retorno: int
+    num_hospedaje: int
+    num_transporte: int
+    num_parqueadero: int
+
+    model_config = {"from_attributes": True}
+
+class RegistroRetornoRespuesta(BaseModel):
+    codigo: int
+    usuario: int
+    retorno: int
+    num_hospedaje: int 
+    num_transporte: int 
+    num_parqueadero: int 
+
+    model_config = {"from_attributes": True}

--- a/app/retornos/esquemas/registro_retorno_esquema.py
+++ b/app/retornos/esquemas/registro_retorno_esquema.py
@@ -1,6 +1,10 @@
+"""
+Modulo que define los esquemas para el registro a un retorno.
+Contiene los esquemas para estructurar los datos de entrada y salida 
+relacionados con el proceso de registro a un retorno.
+"""
 
-from pydantic import BaseModel, Field
-import datetime
+from pydantic import BaseModel
 
 class RegistroRetornoCrear(BaseModel):
     usuario: int

--- a/app/retornos/excepciones/registro_retorno_excepciones.py
+++ b/app/retornos/excepciones/registro_retorno_excepciones.py
@@ -1,3 +1,10 @@
+"""
+Modulo que define las excepciones personalizadas para el proceso de registro a un retorno.
+Contiene las clases de excepciones que se lanzan en el servicio de registro a un retorno 
+para manejar errores específicos como retornos no existentes, usuarios no existentes, 
+usuarios sin colonia, y usuarios ya registrados. 
+"""
+
 from fastapi import HTTPException, status
 
 class RetornoNoExistente(HTTPException):

--- a/app/retornos/excepciones/registro_retorno_excepciones.py
+++ b/app/retornos/excepciones/registro_retorno_excepciones.py
@@ -1,0 +1,36 @@
+from fastapi import HTTPException, status
+
+class RetornoNoExistente(HTTPException):
+    def __init__(self, retorno_id: int):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"El retorno con código {retorno_id} no existe."
+        )
+
+class RetornoEstadoFinalizado(HTTPException):
+    def __init__(self, retorno_id: int):
+        super().__init__(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"No es posible inscribir en el retorno con código {retorno_id} porque ya ha finalizado."
+        )
+
+class UsuarioNoExistente(HTTPException):
+    def __init__(self, usuario_id: int):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"El usuario con código {usuario_id} no existe."
+        )
+
+class UsuarioSinColonia(HTTPException):
+    def __init__(self, usuario_id: int):
+        super().__init__(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"El usuario con código {usuario_id} no pertenece a ninguna colonia."
+        )
+
+class UsuarioYaRegistrado(HTTPException):
+    def __init__(self, usuario_id: int, retorno_id: int):
+        super().__init__(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"El usuario con código {usuario_id} ya está registrado en el retorno con código {retorno_id}."
+        )

--- a/app/retornos/modelos/registro_retorno_modelo.py
+++ b/app/retornos/modelos/registro_retorno_modelo.py
@@ -1,3 +1,9 @@
+"""
+Modulo que define el modelo para el registro a un retorno.
+Aquí se mapea la tabla de registro a un retorno en la base de datos, definiendo 
+sus columnas y relaciones.
+"""
+
 from sqlalchemy import Integer, Boolean, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 from app.core.database import Base

--- a/app/retornos/modelos/registro_retorno_modelo.py
+++ b/app/retornos/modelos/registro_retorno_modelo.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Integer, Boolean, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+from app.core.database import Base
+
+class RegistroRetorno(Base):
+    __tablename__ = 'registro_retorno'
+
+    codigo: Mapped[int] = mapped_column("reg_codigo",Integer, primary_key=True, autoincrement=True)
+    usuario: Mapped[int] = mapped_column("us_codigo", Integer, ForeignKey("usuario.us_codigo"), nullable=False)
+    retorno: Mapped[int] = mapped_column("re_codigo", Integer, ForeignKey("retorno.codigo"), nullable=False)
+    num_hospedaje: Mapped[int] = mapped_column("reg_num_hospedaje", Integer, nullable=False, default=0)
+    num_transporte: Mapped[int] = mapped_column("reg_num_transporte", Integer, nullable=False, default=0)
+    num_parqueadero: Mapped[int] = mapped_column("reg_num_parqueadero", Integer, nullable=False, default=0)
+
+    __table_args__ = (
+        UniqueConstraint("us_codigo", "re_codigo", name="uk1_uk2_registro_retorno"),
+    )

--- a/app/retornos/repositorios/registro_retorno_repositorio.py
+++ b/app/retornos/repositorios/registro_retorno_repositorio.py
@@ -1,3 +1,9 @@
+"""
+Modulo que define el repositorio para el registro a un retorno.
+Contiene los métodos para interactuar con la base de datos relacionados con el 
+proceso de registro a un retorno.
+"""
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoRespuesta
@@ -8,6 +14,7 @@ class RegistroRetornoRepositorio:
         self.db = db
 
     async def crear_registro_retorno(self, registro_retorno: RegistroRetornoCrear) -> RegistroRetorno:
+        """Crea un nuevo registro de retorno en la base de datos."""
         nuevo_registro = RegistroRetorno(
             usuario=registro_retorno.usuario,
             retorno=registro_retorno.retorno,
@@ -20,6 +27,7 @@ class RegistroRetornoRepositorio:
         await self.db.refresh(nuevo_registro)
         return nuevo_registro
     
-    async def obtener_registro_retorno_por_usuario_y_retorno(self, usuario_id, retorno_id):
+    async def obtener_registro_retorno_por_usuario_y_retorno(self, usuario_id, retorno_id): 
+        """Obtiene un registro de retorno específico para un usuario y retorno dados."""
         resultado = await self.db.execute(select(RegistroRetorno).filter(RegistroRetorno.usuario == usuario_id, RegistroRetorno.retorno == retorno_id))
         return resultado.scalars().first()

--- a/app/retornos/repositorios/registro_retorno_repositorio.py
+++ b/app/retornos/repositorios/registro_retorno_repositorio.py
@@ -1,0 +1,25 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoRespuesta
+from app.retornos.modelos.registro_retorno_modelo import RegistroRetorno
+
+class RegistroRetornoRepositorio:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def crear_registro_retorno(self, registro_retorno: RegistroRetornoCrear) -> RegistroRetorno:
+        nuevo_registro = RegistroRetorno(
+            usuario=registro_retorno.usuario,
+            retorno=registro_retorno.retorno,
+            num_hospedaje=registro_retorno.num_hospedaje,
+            num_transporte=registro_retorno.num_transporte,
+            num_parqueadero=registro_retorno.num_parqueadero
+        )
+        self.db.add(nuevo_registro)
+        await self.db.commit()
+        await self.db.refresh(nuevo_registro)
+        return nuevo_registro
+    
+    async def obtener_registro_retorno_por_usuario_y_retorno(self, usuario_id, retorno_id):
+        resultado = await self.db.execute(select(RegistroRetorno).filter(RegistroRetorno.usuario == usuario_id, RegistroRetorno.retorno == retorno_id))
+        return resultado.scalars().first()

--- a/app/retornos/servicios/registro_retorno_servicio.py
+++ b/app/retornos/servicios/registro_retorno_servicio.py
@@ -1,3 +1,10 @@
+"""
+Modulo que define el servicio para el registro a un retorno.
+Contiene la lógica de negocio relacionada con el proceso de registro a un retorno,
+utilizando el repositorio para interactuar con la base de datos y los esquemas para 
+estructurar los datos de entrada y salida.
+"""
+
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.usuarios.repository.usuario_repositorio import UsuarioRepositorio
 from app.retornos.repositorios.registro_retorno_repositorio import RegistroRetornoRepositorio
@@ -13,6 +20,20 @@ class RegistroRetornoServicio:
         self.usuario_servicio = usuario_servicio
 
     async def crear_registro_retorno(self, data: RegistroRetornoCrear) -> RegistroRetornoRespuesta:
+        """
+        Proceso de registro a un retorno, validando que el retorno exista, que el usuario exista 
+        y tenga colonia asignada, y que no esté ya registrado en ese retorno.
+        Parámetros:
+            - data (RegistroRetornoCrear): Esquema con los datos necesarios para crear un registro de retorno.
+        Retorna:
+            - RegistroRetornoRespuesta: Esquema con los datos del registro de retorno creado.
+        Excepciones:
+            - RetornoNoExistente: Si el retorno especificado no existe.
+            - RetornoEstadoFinalizado: Si el retorno especificado ya ha finalizado.
+            - UsuarioNoExistente: Si el usuario especificado no existe.
+            - UsuarioSinColonia: Si el usuario especificado no pertenece a ninguna colonia.
+            - UsuarioYaRegistrado: Si el usuario ya está registrado en el retorno especificado.
+        """
         retorno = await self.retorno_repositorio.get_by_codigo(data.retorno)
         if not retorno:
             raise RetornoNoExistente(data.retorno)
@@ -35,4 +56,12 @@ class RegistroRetornoServicio:
         return await self.repositorio.crear_registro_retorno(data)
 
     async def obtener_registro_retorno_por_usuario_y_retorno(self, usuario_id, retorno_id):
+        """
+        Obtiene un registro de retorno específico para un usuario y retorno dados.
+        Paramétros:
+            - usuario_id (int): ID del usuario.
+            - retorno_id (int): ID del retorno.
+        Retorna:
+            - RegistroRetornoRespuesta: Esquema con los datos del registro de retorno encontrado, o None si no existe. 
+        """
         return await self.repositorio.obtener_registro_retorno_por_usuario_y_retorno(usuario_id, retorno_id)

--- a/app/retornos/servicios/registro_retorno_servicio.py
+++ b/app/retornos/servicios/registro_retorno_servicio.py
@@ -1,0 +1,38 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.usuarios.repository.usuario_repositorio import UsuarioRepositorio
+from app.retornos.repositorios.registro_retorno_repositorio import RegistroRetornoRepositorio
+from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoRespuesta
+from app.retornos.repositorios.retorno_repositorio import RetornoRepository
+from app.usuarios.services.usuario_servicio import UsuarioServicio
+from app.retornos.excepciones.registro_retorno_excepciones import RetornoNoExistente, RetornoEstadoFinalizado, UsuarioNoExistente, UsuarioSinColonia, UsuarioYaRegistrado
+
+class RegistroRetornoServicio:
+    def __init__(self, repositorio: RegistroRetornoRepositorio = None, retorno_repositorio: RetornoRepository = None, usuario_servicio: UsuarioServicio = None) -> None:
+        self.repositorio = repositorio 
+        self.retorno_repositorio = retorno_repositorio
+        self.usuario_servicio = usuario_servicio
+
+    async def crear_registro_retorno(self, data: RegistroRetornoCrear) -> RegistroRetornoRespuesta:
+        retorno = await self.retorno_repositorio.get_by_codigo(data.retorno)
+        if not retorno:
+            raise RetornoNoExistente(data.retorno)
+        
+        if retorno.estado == "finalizado":
+            raise RetornoEstadoFinalizado(data.retorno)
+        
+        usuario = await self.usuario_servicio.obtener_usuario_por_id(data.usuario)
+
+        if not usuario:
+            raise UsuarioNoExistente(data.usuario)
+
+        if not usuario.co_codigo:
+            raise UsuarioSinColonia(data.usuario)
+        
+        usuario_existente = await self.repositorio.obtener_registro_retorno_por_usuario_y_retorno(data.usuario, data.retorno)
+        if usuario_existente:
+            raise UsuarioYaRegistrado(data.usuario, data.retorno)
+        
+        return await self.repositorio.crear_registro_retorno(data)
+
+    async def obtener_registro_retorno_por_usuario_y_retorno(self, usuario_id, retorno_id):
+        return await self.repositorio.obtener_registro_retorno_por_usuario_y_retorno(usuario_id, retorno_id)

--- a/tests/colonias/test_colonia_schemas.py
+++ b/tests/colonias/test_colonia_schemas.py
@@ -24,22 +24,22 @@ def test_crear_colonia_colombia_con_lider():
         pais = "colombia",
         departamento = "antioquia",
         ciudad = "medellín",
-        lider_id = 2
+        lider = 2
     )
 
     assert colonia.pais == "Colombia"
     assert colonia.departamento == "Antioquia"
     assert colonia.ciudad == "Medellín"
-    assert colonia.lider_id == 2
+    assert colonia.lider == 2
 
 def test_crear_colonia_extranjera_con_lider():
     colonia = ColoniaCrear(
         pais = "españa",
-        lider_id = 3
+        lider = 3
     )
 
     assert colonia.pais == "España"
-    assert colonia.lider_id == 3
+    assert colonia.lider == 3
 
 def test_crear_colonia_colombia_sin_departamento_ciudad():
     with pytest.raises(ValueError):

--- a/tests/retornos/test_registro_retorno.py
+++ b/tests/retornos/test_registro_retorno.py
@@ -1,10 +1,146 @@
-from unittest import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock
 import sys
 import os
+from app.retornos.excepciones.registro_retorno_excepciones import RetornoEstadoFinalizado, RetornoNoExistente, UsuarioNoExistente, UsuarioSinColonia, UsuarioYaRegistrado
 import pytest
+
+from app.retornos.servicios.registro_retorno_servicio import RegistroRetornoServicio
 
 @pytest.fixture
 def mock_repositorio():
     repositorio = MagicMock()
-    repositorio.registrar_retorno = AsyncMock()
+    repositorio.crear_registro_retorno = AsyncMock()
+    repositorio.obtener_registro_retorno_por_usuario_y_retorno = AsyncMock()
     return repositorio
+
+@pytest.fixture
+def mock_retorno_repositorio():
+    repositorio = MagicMock()
+    repositorio.get_by_codigo = AsyncMock()
+    return repositorio
+
+@pytest.fixture
+def mock_usuario_servicio():
+    servicio = MagicMock()
+    servicio.obtener_usuario_por_id = AsyncMock()
+    return servicio
+
+@pytest.fixture
+def servicio(mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio):
+    return RegistroRetornoServicio(mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio)
+
+@pytest.fixture
+def retorno_mock():
+    retorno = MagicMock()
+    retorno.anio = 2026
+    retorno.estado = "activo"
+
+    return retorno
+
+@pytest.fixture
+def usuario_mock():
+    usuario = MagicMock()
+    usuario.us_codigo = 1
+    usuario.co_codigo = 2
+    return usuario
+
+@pytest.fixture
+def registro_retorno_mock():
+    registro = MagicMock()
+    registro.reg_codigo = 1
+    registro.us_codigo = 1
+    registro.re_codigo = 1
+    return registro
+
+
+@pytest.mark.asyncio
+async def test_crear_registro_retorno_exitoso(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock, usuario_mock, registro_retorno_mock):
+    data = MagicMock()
+    data.usuario = 1
+    data.retorno = 1
+
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
+    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.return_value = None
+    mock_repositorio.crear_registro_retorno.return_value = registro_retorno_mock
+
+    resultado = await servicio.crear_registro_retorno(data)
+
+    mock_retorno_repositorio.get_by_codigo.assert_called_once_with(1)
+    mock_usuario_servicio.obtener_usuario_por_id.assert_called_once_with(1)
+    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.assert_called_once_with(1, 1)
+    mock_repositorio.crear_registro_retorno.assert_called_once_with(data)
+    assert resultado == registro_retorno_mock
+
+@pytest.mark.asyncio
+async def test_crear_registro_retorno_retorno_no_existente(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio):
+    data = MagicMock()
+    data.usuario = 1
+    data.retorno = 1
+
+    mock_retorno_repositorio.get_by_codigo.return_value = None
+
+    with pytest.raises(RetornoNoExistente) as exc_info:
+        await servicio.crear_registro_retorno(data)
+
+    assert exc_info.value.detail == "El retorno con código 1 no existe."
+
+@pytest.mark.asyncio
+async def test_crear_registro_retorno_retorno_finalizado(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock):
+    data = MagicMock()
+    data.usuario = 1
+    data.retorno = 1
+
+    retorno_mock.estado = "finalizado"
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+
+    with pytest.raises(RetornoEstadoFinalizado) as exc_info:
+        await servicio.crear_registro_retorno(data)
+
+    assert exc_info.value.detail == "No es posible inscribir en el retorno con código 1 porque ya ha finalizado."
+
+@pytest.mark.asyncio
+async def test_crear_registro_retorno_usuario_no_existente(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock):
+    data = MagicMock()
+    data.usuario = 1
+    data.retorno = 1
+
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = None
+
+    with pytest.raises(UsuarioNoExistente) as exc_info:
+        await servicio.crear_registro_retorno(data)
+
+    assert exc_info.value.detail == "El usuario con código 1 no existe."
+
+@pytest.mark.asyncio
+async def test_crear_registro_retorno_usuario_sin_colonia(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock):
+    data = MagicMock()
+    data.usuario = 1
+    data.retorno = 1
+
+    usuario_mock = MagicMock()
+    usuario_mock.co_codigo = None
+
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
+
+    with pytest.raises(UsuarioSinColonia) as exc_info:
+        await servicio.crear_registro_retorno(data)
+
+    assert exc_info.value.detail == "El usuario con código 1 no pertenece a ninguna colonia."
+
+@pytest.mark.asyncio
+async def test_crear_registro_retorno_usuario_ya_registrado(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock, usuario_mock):
+    data = MagicMock()
+    data.usuario = 1
+    data.retorno = 1
+
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
+    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.return_value = MagicMock()
+
+    with pytest.raises(UsuarioYaRegistrado) as exc_info:
+        await servicio.crear_registro_retorno(data)
+
+    assert exc_info.value.detail == "El usuario con código 1 ya está registrado en el retorno con código 1."

--- a/tests/retornos/test_registro_retorno.py
+++ b/tests/retornos/test_registro_retorno.py
@@ -1,0 +1,10 @@
+from unittest import AsyncMock, MagicMock
+import sys
+import os
+import pytest
+
+@pytest.fixture
+def mock_repositorio():
+    repositorio = MagicMock()
+    repositorio.registrar_retorno = AsyncMock()
+    return repositorio


### PR DESCRIPTION
## Descripción del Cambio
Permite a un usuario inscribirse a un retorno activo. Se valida que el retorno 
exista y esté activo, que el usuario exista y tenga una colonia asignada, 
y que no esté ya inscrito en ese retorno.

## ID de la Historia de Usuario
- **HU:** 2GR-2

## Checklist de Autorevisión
- [x] ¿El código sigue el estándar PEP 8?
- [x] ¿La nomenclatura es correcta (snake_case en español)?
- [x] ¿Los modelos y esquemas están dentro de su módulo correspondiente?
- [x] ¿Se incluyeron pruebas unitarias?
- [x] ¿Las validaciones de negocio están implementadas?

## ¿Cómo probar este cambio?
**Backend:**
1. Levantar con `docker compose up --build`
2. Probar en Swagger (`/docs`) en `POST /api/v1/retornos/registro` con:
   - Inscripción exitosa: `{"usuario": 1, "retorno": 1, "num_hospedaje": 1, "num_transporte": 1, "num_parqueadero": 0}`
   - Usuario sin colonia → 400
   - Retorno finalizado → 400
   - Usuario ya inscrito → 409
   - Retorno inexistente → 404