### PR TITLE
fix(asignar-lider): error validaciones en asignar lider

### DIFF
--- a/app/colonias/repositories/colonia_repository.py
+++ b/app/colonias/repositories/colonia_repository.py
@@ -66,7 +66,11 @@ class ColoniaRepository:
         colonia = await self.obtener_colonia_por_id(colonia_codigo)
         colonia.lider = lider_id
         usuario = await self.db.get(Usuario, lider_id)
-        usuario.ro_codigo = 2 #Revisar si es necesario cambiar el rol del usuario a lider
+        usuario.ro_codigo = 2 #Cambia rol a líder
+
+        if usuario.co_codigo is None:
+            usuario.co_codigo = colonia_codigo
+
         await self.db.commit()
         await self.db.refresh(colonia)
         return colonia

--- a/app/colonias/services/colonia_services.py
+++ b/app/colonias/services/colonia_services.py
@@ -72,6 +72,10 @@ class ColoniaService:
         if not usuario_lider:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                             detail=f"Usuario con ID {lider_id} no encontrado")
+        
+        if colonia.lider != 0:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT,
+                            detail=f"La colonia con código {colonia_codigo} ya tiene un líder asignado")
 
         colonia_actualizada = await self.repositorio.establecer_lider_colonia(colonia_codigo, lider_id)
         return ColoniaRespuesta.model_validate(colonia_actualizada, from_attributes=True)


### PR DESCRIPTION
## Descripción del Cambio
Se implementa la lógica para asignar automáticamente una colonia a un usuario cuando es designado como líder de esa colonia, si el usuario aún no tiene una colonia asociada. Y la excepción para cuando una colonia ya tiene un líder asignado.

**Cambios realizados:**
- Actualización del método `establecer_lider_colonia()` en `ColoniaRepository` para aceptar parámetro `asignar_colonia`
- Actualización de `servicio_establecer_lider()` en `ColoniaService` para lanzar una excepción cuando la colonia ya tienen líder asignado.
- Se valida que el usuario no tenga colonia antes de asignársela
- El rol del usuario se actualiza a líder (ro_codigo = 2) al ser asignado

## ID de la Historia de Usuario
- **HU:** [3GC-5] Establecer líder de colonia.

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [ ] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%? *(Pendiente)*
- [x] ¿Las validaciones de negocio (usuario sin colonia, colonia sin líder, etc.) están implementadas?

## ¿Cómo probar este cambio?
**Backend:**
1. Levantar con Docker: `docker-compose up --build`
2. Probar en Swagger (`http://localhost:8000/docs`):
   - Endpoint: `POST /colonias/{colonia_codigo}/lider/{lider_id}`
   - Datos de prueba:
     - `colonia_codigo: 1`
     - `lider_id: 5` (usuario sin colonia asociada)
     - **Resultado esperado:** Usuario asignado como líder y se le asigna la colonia automáticamente

**Validaciones a verificar:**
- ✅ Si el usuario YA tiene colonia, no se debe cambiar
- ✅ Si la colonia YA tiene líder, lanzar error 409 (Conflict)
- ✅ Si usuario o colonia no existen, lanzar error 404