### PR TITLE
2GR-3 Darse de baja retorno

### DIFF
--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -4,7 +4,7 @@ Expone operaciones de creación y consulta bajo el prefijo /retornos,
 con documentación Swagger integrada.
 """
 
-from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoRespuesta
+from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoDarseDeBaja, RegistroRetornoRespuesta
 from app.retornos.repositorios.registro_retorno_repositorio import RegistroRetornoRepositorio
 from app.retornos.repositorios.retorno_repositorio import RetornoRepository
 from app.retornos.servicios.registro_retorno_servicio import RegistroRetornoServicio
@@ -101,3 +101,17 @@ async def obtener_retorno(codigo: int, db: AsyncSession = Depends(get_db)):
 )
 async def inscribir_usuario_en_retorno(registro: RegistroRetornoCrear, servicio: RegistroRetornoServicio = Depends(obtener_registro_retorno_servicio)):
     return await servicio.crear_registro_retorno(registro)
+
+
+@router.delete(
+    "/darse-de-baja",
+    response_model= str,
+    summary="Darse de baja de un retorno",
+    description="Permite a un usuario darse de baja de un retorno específico.",
+)
+async def darse_de_baja(datos: RegistroRetornoDarseDeBaja, servicio: RegistroRetornoServicio = Depends(obtener_registro_retorno_servicio)):
+    resultado = await servicio.darse_de_baja(datos)
+    if resultado:
+        return {"detail": "Usuario dado de baja exitosamente del retorno."}
+    else:
+        return {"detail": "No se encontró un registro de retorno para el usuario y retorno especificados."}

--- a/app/retornos/esquemas/registro_retorno_esquema.py
+++ b/app/retornos/esquemas/registro_retorno_esquema.py
@@ -24,3 +24,9 @@ class RegistroRetornoRespuesta(BaseModel):
     num_parqueadero: int 
 
     model_config = {"from_attributes": True}
+
+class RegistroRetornoDarseDeBaja(BaseModel):
+    usuario: int
+    retorno: int
+
+    model_config = {"from_attributes": True}

--- a/app/retornos/excepciones/registro_retorno_excepciones.py
+++ b/app/retornos/excepciones/registro_retorno_excepciones.py
@@ -21,11 +21,24 @@ class RetornoEstadoFinalizado(HTTPException):
             detail=f"No es posible inscribir en el retorno con código {retorno_id} porque ya ha finalizado."
         )
 
+class RetornoEstadoFinalizadoDarseDeBaja(HTTPException):
+    def __init__(self, retorno_id: int):
+        super().__init__(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"No es posible darse de baja en el retorno con código {retorno_id} porque ya ha finalizado."
+        )
 class UsuarioNoExistente(HTTPException):
     def __init__(self, usuario_id: int):
         super().__init__(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"El usuario con código {usuario_id} no existe."
+        )
+
+class UsuarioNoRegistradoEnRetorno(HTTPException):
+    def __init__(self, usuario_id: int, retorno_id: int):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"El usuario con código {usuario_id} no está registrado en el retorno con código {retorno_id}."
         )
 
 class UsuarioSinColonia(HTTPException):

--- a/app/retornos/repositorios/registro_retorno_repositorio.py
+++ b/app/retornos/repositorios/registro_retorno_repositorio.py
@@ -6,7 +6,7 @@ proceso de registro a un retorno.
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoRespuesta
+from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoDarseDeBaja, RegistroRetornoRespuesta
 from app.retornos.modelos.registro_retorno_modelo import RegistroRetorno
 
 class RegistroRetornoRepositorio:
@@ -31,3 +31,13 @@ class RegistroRetornoRepositorio:
         """Obtiene un registro de retorno específico para un usuario y retorno dados."""
         resultado = await self.db.execute(select(RegistroRetorno).filter(RegistroRetorno.usuario == usuario_id, RegistroRetorno.retorno == retorno_id))
         return resultado.scalars().first()
+    
+    async def eliminar_registro_retorno(self, datos: RegistroRetornoDarseDeBaja) -> bool:
+        """Elimina un registro de retorno específico para un usuario y retorno dados."""
+        resultado = await self.db.execute(select(RegistroRetorno).filter(RegistroRetorno.usuario == datos.usuario, RegistroRetorno.retorno == datos.retorno))
+        registro = resultado.scalars().first()
+        if registro:
+            await self.db.delete(registro)
+            await self.db.commit()
+            return True
+        return False

--- a/app/retornos/servicios/registro_retorno_servicio.py
+++ b/app/retornos/servicios/registro_retorno_servicio.py
@@ -8,7 +8,7 @@ estructurar los datos de entrada y salida.
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.usuarios.repository.usuario_repositorio import UsuarioRepositorio
 from app.retornos.repositorios.registro_retorno_repositorio import RegistroRetornoRepositorio
-from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoRespuesta
+from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoDarseDeBaja, RegistroRetornoRespuesta
 from app.retornos.repositorios.retorno_repositorio import RetornoRepository
 from app.usuarios.services.usuario_servicio import UsuarioServicio
 from app.retornos.excepciones.registro_retorno_excepciones import RetornoNoExistente, RetornoEstadoFinalizado, UsuarioNoExistente, UsuarioSinColonia, UsuarioYaRegistrado
@@ -65,3 +65,14 @@ class RegistroRetornoServicio:
             - RegistroRetornoRespuesta: Esquema con los datos del registro de retorno encontrado, o None si no existe. 
         """
         return await self.repositorio.obtener_registro_retorno_por_usuario_y_retorno(usuario_id, retorno_id)
+    
+    async def darse_de_baja(self, datos:RegistroRetornoDarseDeBaja):
+        """
+        Permite a un usuario darse de baja de un retorno específico, eliminando su registro de retorno.
+        Parámetros:
+            - usuario_id (int): ID del usuario.
+            - retorno_id (int): ID del retorno.
+        Retorna:
+            - bool: True si el registro de retorno fue eliminado exitosamente, False si no se encontró el registro.
+        """
+        return await self.repositorio.eliminar_registro_retorno(datos)

--- a/app/retornos/servicios/registro_retorno_servicio.py
+++ b/app/retornos/servicios/registro_retorno_servicio.py
@@ -11,7 +11,7 @@ from app.retornos.repositorios.registro_retorno_repositorio import RegistroRetor
 from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoDarseDeBaja, RegistroRetornoRespuesta
 from app.retornos.repositorios.retorno_repositorio import RetornoRepository
 from app.usuarios.services.usuario_servicio import UsuarioServicio
-from app.retornos.excepciones.registro_retorno_excepciones import RetornoNoExistente, RetornoEstadoFinalizado, UsuarioNoExistente, UsuarioSinColonia, UsuarioYaRegistrado
+from app.retornos.excepciones.registro_retorno_excepciones import RetornoEstadoFinalizadoDarseDeBaja, RetornoNoExistente, RetornoEstadoFinalizado, UsuarioNoExistente, UsuarioNoRegistradoEnRetorno, UsuarioSinColonia, UsuarioYaRegistrado
 
 class RegistroRetornoServicio:
     def __init__(self, repositorio: RegistroRetornoRepositorio = None, retorno_repositorio: RetornoRepository = None, usuario_servicio: UsuarioServicio = None) -> None:
@@ -66,13 +66,25 @@ class RegistroRetornoServicio:
         """
         return await self.repositorio.obtener_registro_retorno_por_usuario_y_retorno(usuario_id, retorno_id)
     
-    async def darse_de_baja(self, datos:RegistroRetornoDarseDeBaja):
+    async def darse_de_baja(self, datos: RegistroRetornoDarseDeBaja):
         """
         Permite a un usuario darse de baja de un retorno específico, eliminando su registro de retorno.
-        Parámetros:
-            - usuario_id (int): ID del usuario.
-            - retorno_id (int): ID del retorno.
         Retorna:
             - bool: True si el registro de retorno fue eliminado exitosamente, False si no se encontró el registro.
         """
+        retorno = await self.retorno_repositorio.get_by_codigo(datos.retorno)
+        if not retorno:
+            raise RetornoNoExistente(datos.retorno)
+        
+        if retorno.estado == "finalizado":
+            raise RetornoEstadoFinalizadoDarseDeBaja(datos.retorno)
+        
+        usuario = await self.usuario_servicio.obtener_usuario_por_id(datos.usuario)
+
+        if not usuario:
+            raise UsuarioNoExistente(datos.usuario)
+        usuario_registrado = await self.repositorio.obtener_registro_retorno_por_usuario_y_retorno(datos.usuario, datos.retorno)
+        if not usuario_registrado:
+            raise UsuarioNoRegistradoEnRetorno(datos.usuario, datos.retorno)
+        
         return await self.repositorio.eliminar_registro_retorno(datos)

--- a/tests/retornos/test_darse_de_baja_retorno.py
+++ b/tests/retornos/test_darse_de_baja_retorno.py
@@ -1,0 +1,134 @@
+"""
+    pruebas de la funcion darse de baja de un retorno de forma individual
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+import sys
+import os
+import pytest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+from app.retornos.excepciones.registro_retorno_excepciones import RetornoEstadoFinalizado, RetornoEstadoFinalizadoDarseDeBaja, RetornoNoExistente, UsuarioNoExistente, UsuarioNoRegistradoEnRetorno
+from app.retornos.servicios.registro_retorno_servicio import RegistroRetornoServicio
+
+@pytest.fixture
+def mock_repositorio():
+    repositorio = MagicMock()
+    repositorio.crear_registro_retorno = AsyncMock()
+    repositorio.obtener_registro_retorno_por_usuario_y_retorno = AsyncMock()
+    repositorio.eliminar_registro_retorno = AsyncMock()
+    return repositorio
+
+@pytest.fixture
+def mock_retorno_repositorio():
+    repositorio = MagicMock()
+    repositorio.get_by_codigo = AsyncMock()
+    return repositorio
+
+@pytest.fixture
+def mock_usuario_servicio():
+    servicio = MagicMock()
+    servicio.obtener_usuario_por_id = AsyncMock()
+    return servicio
+
+@pytest.fixture
+def servicio(mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio):
+    return RegistroRetornoServicio(mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio)
+
+@pytest.fixture
+def retorno_mock():
+    retorno = MagicMock()
+    retorno.anio = 2026
+    retorno.estado = "activo"
+
+    return retorno
+
+@pytest.fixture
+def retorno_finalizado_mock():
+    retorno = MagicMock()
+    retorno.anio = 2026
+    retorno.estado = "finalizado"
+    return retorno
+
+@pytest.fixture
+def usuario_mock():
+    usuario = MagicMock()
+    usuario.us_codigo = 1
+    usuario.co_codigo = 2
+    return usuario
+
+@pytest.fixture
+def registro_retorno_mock():
+    registro = MagicMock()
+    registro.reg_codigo = 1
+    registro.us_codigo = 1
+    registro.re_codigo = 1
+    return registro
+
+
+@pytest.mark.asyncio
+async def test_darse_baja_retorno_exitoso(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock, usuario_mock, registro_retorno_mock):
+    data = MagicMock()
+    data.usuario = 1
+    data.retorno = 1
+
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.return_value = registro_retorno_mock
+    mock_repositorio.eliminar_registro_retorno.return_value = True
+    resultado = await servicio.darse_de_baja(data)
+
+    assert resultado == True
+
+@pytest.mark.asyncio
+async def test_darse_baja_retorno_usuario_no_existe(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock, usuario_mock, registro_retorno_mock):
+    data = MagicMock()
+    data.usuario = 1
+    data.retorno = 1
+
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = None
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+    with pytest.raises(UsuarioNoExistente) as exc_info:
+        await servicio.darse_de_baja(data)
+
+    assert exc_info.value.detail == "El usuario con código 1 no existe."
+
+@pytest.mark.asyncio
+async def test_darse_baja_retorno_usuario_no_registrado_en_retorno(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock, usuario_mock, registro_retorno_mock):
+    data = MagicMock()
+    data.usuario = 1
+    data.retorno = 1
+
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.return_value = None
+    with pytest.raises(UsuarioNoRegistradoEnRetorno) as exc_info:
+        await servicio.darse_de_baja(data)
+
+    assert exc_info.value.detail == "El usuario con código 1 no está registrado en el retorno con código 1."
+
+@pytest.mark.asyncio
+async def test_darse_baja_retorno_retorno_no_existe(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock, usuario_mock, registro_retorno_mock):
+    data = MagicMock()
+    data.usuario = 1
+    data.retorno = 1
+
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
+    mock_retorno_repositorio.get_by_codigo.return_value = None
+    with pytest.raises(RetornoNoExistente) as exc_info:
+        await servicio.darse_de_baja(data)
+    
+    assert exc_info.value.detail == "El retorno con código 1 no existe."
+
+@pytest.mark.asyncio
+async def test_darse_baja_retorno_retorno_finalizado(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_finalizado_mock, usuario_mock, registro_retorno_mock):
+    data = MagicMock()
+    data.usuario = 1
+    data.retorno = 1
+
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_finalizado_mock
+    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.return_value = registro_retorno_mock
+    with pytest.raises(RetornoEstadoFinalizadoDarseDeBaja) as exc_info:
+        await servicio.darse_de_baja(data)
+
+    assert exc_info.value.detail == "No es posible darse de baja en el retorno con código 1 porque ya ha finalizado."


### PR DESCRIPTION
## Descripción del Cambio
Implementación de la funcionalidad de la Darse de baja de un retorno.
- crea el esquema RegistroRetornoDarseDeBaja
- crea el metodo eliminar_registro_retorno en el repositorio registro_retorno_repositorio
- crea el metodo darse_de_baja en registro_retorno_servicio
- crea el endpoint darse_de_baja en retorno_router 
- crea la excepcion RetornoEstadoFinalizadoDarseDeBaja en registro_retorno_excepciones
## ID de la Historia de Usuario
- **HU:** 2GR-3

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [x] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%?
- [x] ¿Las validaciones de negocio (Documento > 0, Celular 10 dígitos, etc.) están implementadas?

## ¿Cómo probar este cambio?
**Backend:**
1. En el directorio raiz, ejecutar el siguiente comando:
```
 pytest tests/retornos/test_darse_de_baja_retorno.py -v
```
