### PR TITLE
Feat/consultas personas y grupos retorno

### DIFF
--- a/app/retornos/api/v1/endpoints/persona_router.py
+++ b/app/retornos/api/v1/endpoints/persona_router.py
@@ -58,8 +58,3 @@ async def obtener_persona_por_documento(documento:str, servicio: Annotated[Perso
 async def listar_personas(servicio: Annotated[PersonaServicio, Depends(get_persona_servicio)]):
     """Lista todas las personas registradas en el sistema."""
     return await servicio.repositorio.obtener_todas_las_personas()
-"""
-Este archivo ha sido deprecado. 
-Los endpoints de personas han sido movidos a app/retornos/api/v1/endpoints/retorno_router.py
-bajo el prefijo /grupoRetorno.
-"""

--- a/app/retornos/api/v1/endpoints/persona_router.py
+++ b/app/retornos/api/v1/endpoints/persona_router.py
@@ -53,6 +53,10 @@ async def obtener_persona_por_documento(documento:str, servicio: Annotated[Perso
         return None
     return PersonaRespuesta.model_validate(persona)
 
+@router.get("/registro/{us_codigo}/{re_codigo}", response_model=bool)
+async def verificar_registro_persona_retorno(pe_codigo: int, re_codigo: int, servicio: Annotated[PersonaServicio, Depends(get_persona_servicio)]):
+        """Verifica si una persona está registrada para un retorno específico."""
+        return await servicio.verificar_registro_persona_retorno(pe_codigo, re_codigo)
 
 @router.get("/",response_model=List[PersonaRespuesta])
 async def listar_personas(servicio: Annotated[PersonaServicio, Depends(get_persona_servicio)]):

--- a/app/retornos/api/v1/endpoints/persona_router.py
+++ b/app/retornos/api/v1/endpoints/persona_router.py
@@ -38,25 +38,39 @@ async def obtener_personas_de_grupo(
     """Lista todas las personas que pertenecen a un grupo específico."""
     return await servicio.listar_personas_por_grupo(gr_codigo)
 
-@router.get("/{pe_codigo}", response_model=PersonaRespuesta)
+@router.get("/{pe_codigo}", response_model=PersonaRespuesta,
+            status_code=status.HTTP_200_OK,
+            summary="Obtener persona por ID",
+            description="Obtiene los detalles de una persona por su código.")
 async def obtener_persona_por_id(pe_codigo:int, servicio: Annotated[PersonaServicio, Depends(get_persona_servicio)]):
     """Obtiene los detalles de una persona por su código."""
-    persona = await servicio.repositorio.obtener_por_id(pe_codigo)
-    if not persona:
-        return None
+    persona = await servicio.obtener_persona_por_id(pe_codigo)
     return PersonaRespuesta.model_validate(persona)
 
-@router.get("/documento/{documento}", response_model=PersonaRespuesta)
+@router.get("/documento/{documento}", 
+            response_model=PersonaRespuesta, 
+            status_code=status.HTTP_200_OK,
+             summary="Obtener persona por documento",
+             description="Obtiene los detalles de una persona por su número de documento.")
 async def obtener_persona_por_documento(documento:str, servicio: Annotated[PersonaServicio, Depends(get_persona_servicio)]):
-    persona = await servicio.repositorio.obtener_persona_por_documento(documento)
-    if not persona:
-        return None
+    persona = await servicio.obtener_persona_por_documento(documento)
     return PersonaRespuesta.model_validate(persona)
 
-@router.get("/registro/{us_codigo}/{re_codigo}", response_model=bool)
+@router.get("/registro-documento/{pe_documento}/{re_codigo}", response_model=bool,
+            status_code=status.HTTP_200_OK,
+            summary="Verificar registro de persona para retorno",
+            description="Verifica si una persona está registrada para un retorno específico.")
+async def verificar_registro_persona_retorno(pe_documento: str, re_codigo: int, servicio: Annotated[PersonaServicio, Depends(get_persona_servicio)]):
+        """Verifica si una persona está registrada para un retorno específico."""
+        return await servicio.verificar_registro_retorno_persona_por_documento(pe_documento, re_codigo)
+
+@router.get("/registro-id/{pe_codigo}/{re_codigo}", response_model=bool,
+            status_code=status.HTTP_200_OK,
+            summary="Verificar registro de persona para retorno",
+            description="Verifica si una persona está registrada para un retorno específico.")
 async def verificar_registro_persona_retorno(pe_codigo: int, re_codigo: int, servicio: Annotated[PersonaServicio, Depends(get_persona_servicio)]):
         """Verifica si una persona está registrada para un retorno específico."""
-        return await servicio.verificar_registro_persona_retorno(pe_codigo, re_codigo)
+        return await servicio.verificar_registro_retorno_persona(pe_codigo, re_codigo)
 
 @router.get("/",response_model=List[PersonaRespuesta])
 async def listar_personas(servicio: Annotated[PersonaServicio, Depends(get_persona_servicio)]):

--- a/app/retornos/api/v1/endpoints/persona_router.py
+++ b/app/retornos/api/v1/endpoints/persona_router.py
@@ -37,6 +37,27 @@ async def obtener_personas_de_grupo(
 ):
     """Lista todas las personas que pertenecen a un grupo específico."""
     return await servicio.listar_personas_por_grupo(gr_codigo)
+
+@router.get("/{pe_codigo}", response_model=PersonaRespuesta)
+async def obtener_persona_por_id(pe_codigo:int, servicio: Annotated[PersonaServicio, Depends(get_persona_servicio)]):
+    """Obtiene los detalles de una persona por su código."""
+    persona = await servicio.repositorio.obtener_por_id(pe_codigo)
+    if not persona:
+        return None
+    return PersonaRespuesta.model_validate(persona)
+
+@router.get("/documento/{documento}", response_model=PersonaRespuesta)
+async def obtener_persona_por_documento(documento:str, servicio: Annotated[PersonaServicio, Depends(get_persona_servicio)]):
+    persona = await servicio.repositorio.obtener_persona_por_documento(documento)
+    if not persona:
+        return None
+    return PersonaRespuesta.model_validate(persona)
+
+
+@router.get("/",response_model=List[PersonaRespuesta])
+async def listar_personas(servicio: Annotated[PersonaServicio, Depends(get_persona_servicio)]):
+    """Lista todas las personas registradas en el sistema."""
+    return await servicio.repositorio.obtener_todas_las_personas()
 """
 Este archivo ha sido deprecado. 
 Los endpoints de personas han sido movidos a app/retornos/api/v1/endpoints/retorno_router.py

--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -128,6 +128,13 @@ async def verificar_usuario_registrado(us_codigo: int, re_codigo: int, servicio:
     registro_usuario = await servicio.obtener_registro_retorno_por_usuario_y_retorno(us_codigo, re_codigo)
     return bool(registro_usuario)
 
+@router.get("/vigente",
+            response_model=RetornoResponse | None,
+            summary="Obtener el retorno vigente",
+            description="Retorna el retorno que está actualmente activo o en curso, si existe.")
+async def obtener_retorno_vigente(servicio: Annotated[RetornoService, Depends(obtener_retorno_servicio)]):
+    return await servicio.obtener_retorno_vigente()
+
 @router.get(
     "/",
     response_model=list[RetornoResponse],

--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -330,8 +330,8 @@ async def registrar_grupo_en_retorno_endpoint(
 @grupo_retorno_router.get(
     "/{gr_codigo}/miembros",
     response_model=List[UsuarioSalida],
-    summary="Ver usuarios pertenecientes a un grupo",
-    description="Lista todos los usuarios que han aceptado unirse y forman parte activa de un grupo de retorno."
+    summary="Ver miembros pertenecientes a un grupo",
+    description="Lista todos los miembros (personas y usuarios) que han aceptado unirse y forman parte activa de un grupo de retorno."
 )
 async def obtener_miembros_grupo_endpoint(
     gr_codigo: int,
@@ -340,7 +340,7 @@ async def obtener_miembros_grupo_endpoint(
     """
     Endpoint para obtener la lista de integrantes de un grupo.
     """
-    return await servicio.obtener_usuarios_por_grupo(gr_codigo)
+    return await servicio.obtener_miembros_por_grupo(gr_codigo)
 @grupo_retorno_router.patch("/solicitudes/aceptar/{solicitud_id}", 
               response_model= SolicitudRetornoGrupoRespuesta,
               status_code= status.HTTP_200_OK,
@@ -374,5 +374,21 @@ async def obtener_solicitudes_recientes_grupo_por_usuario(usuario_id: int, servi
             description="Obtiene las solicitudes de ingreso a grupos de retorno enviadas por el lider del grupo.")
 async def obtener_solicitudes_grupo_por_lider(grupo_retorno_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
     return await servicio.obtener_solicitudes_por_grupo_retorno(grupo_retorno_id)
+
+@grupo_retorno_router.get("/grupo/usuario/{usuario_id}/{retorno_id}",    
+                          response_model=GrupoRetornoRespuesta | None,
+                          status_code=status.HTTP_200_OK,
+                            summary="Obtener grupo de retorno por usuario",
+                            description="Obtiene el grupo de retorno al que pertenece un usuario específico.")
+async def obtener_grupo_por_usuario(usuario_id: int, retorno_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+    return await servicio.obtener_grupo_por_usuario_retorno(usuario_id, retorno_id)
+
+@grupo_retorno_router.get("/grupo/usuarios/{gr_codigo}/",
+                            response_model=List[UsuarioSalida],
+                            status_code=status.HTTP_200_OK,
+                                summary="Obtener usuarios por grupo de retorno",
+                                description="Obtiene la lista de usuarios que pertenecen a un grupo de retorno específico.")
+async def obtener_usuarios_por_grupo(gr_codigo: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+    return await servicio.obtener_usuarios_por_grupo(gr_codigo)
 
     

--- a/app/retornos/excepciones/registro_retorno_excepciones.py
+++ b/app/retornos/excepciones/registro_retorno_excepciones.py
@@ -87,3 +87,17 @@ class UsuarioNoPerteneceAlaMismaColonia(HTTPException):
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"El usuario con código {usuario_id} no pertenece a la misma colonia que el lider del grupo {lider_id}."
         )
+
+class UsuarioNoEstaEnUnGrupo(HTTPException):
+    def __init__(self, usuario_id: int, retorno_id: int):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"El usuario con código {usuario_id} no está en ningún grupo para el retorno con código {retorno_id}."
+        )
+
+class GrupoNoEncontrado(HTTPException):
+    def __init__(self, gr_codigo: int):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"El grupo con código {gr_codigo} no existe."
+        )

--- a/app/retornos/excepciones/retorno_excepciones.py
+++ b/app/retornos/excepciones/retorno_excepciones.py
@@ -49,6 +49,13 @@ class RetornoEstadoActivoaFinalizadoError(HTTPException):
             detail="No se puede finalizar un retorno que está activo."
         )
 
+class RetornoVigenteError(HTTPException):
+    """Se lanza cuando se intenta crear un nuevo retorno mientras otro está vigente."""
+    def __init__(self):
+        super().__init__(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No se puede crear un nuevo retorno mientras otro está vigente."
+        )
 class RetornoEstadoEnCursoaActivoError(HTTPException):
     """Se lanza cuando se intenta reactivar un retorno que está en curso."""
     def __init__(self):

--- a/app/retornos/excepciones/retorno_excepciones.py
+++ b/app/retornos/excepciones/retorno_excepciones.py
@@ -92,3 +92,11 @@ class RetornoYaEnEstadoSolicitadoError(HTTPException):
             detail=f"El retorno ya se encuentra en estado '{estado}'. "
             f"No es necesario cambiar de estado."
         )
+
+class NoHayRetornoVigenteError(HTTPException):
+    """Se lanza cuando se intenta obtener un retorno vigente pero no existe ninguno."""
+    def __init__(self):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No hay ningún retorno vigente en este momento."
+        )

--- a/app/retornos/repositorios/persona_repositorio.py
+++ b/app/retornos/repositorios/persona_repositorio.py
@@ -79,3 +79,15 @@ class PersonaRepositorio:
         )
         result = await self.db.execute(stmt)
         return result.scalars().first() is not None
+    
+    async def obtener_todas_las_personas(self) -> List[Persona]:
+        result = await self.db.execute(select(Persona))
+        return list(result.scalars().all())
+    
+    async def obtener_persona_por_id(self, pe_codigo: int) -> Optional[Persona]:
+        result = await self.db.execute(select(Persona).where(Persona.pe_codigo == pe_codigo))
+        return result.scalars().first()
+    
+    async def obtener_persona_por_documento(self, documento: str) -> Optional[Persona]:
+        result = await self.db.execute(select(Persona).where(Persona.pe_documento == documento))
+        return result.scalars().first()

--- a/app/retornos/repositorios/retorno_grupo_usuario_repositorio.py
+++ b/app/retornos/repositorios/retorno_grupo_usuario_repositorio.py
@@ -4,10 +4,12 @@
 
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from app.retornos.modelos.grupo_retorno_modelo import GrupoRetorno
 from app.retornos.modelos.retorno_grupo_usuario_modelo import RetornoGrupoUsuario
 from app.retornos.modelos.registro_retorno_grupo_modelo import RegistroRetornoGrupo
 from app.usuarios.models.usuario import Usuario
-
+from sqlalchemy.orm import selectinload
 class RetornoGrupoUsuarioRepositorio:
     def __init__(self, db: AsyncSession):
         self.db = db
@@ -52,3 +54,20 @@ class RetornoGrupoUsuarioRepositorio:
         )
         result = await self.db.execute(stmt)
         return result.scalar() or 0
+    
+    
+
+    async def obtener_grupo_por_usuario_retorno(self, usuario_id: int, retorno_id: int):
+        """Obtiene el grupo de retorno al que pertenece un usuario específico para un retorno dado."""
+        stmt = (select(RetornoGrupoUsuario)
+            .options(selectinload(RetornoGrupoUsuario.grupo))
+            .join(RegistroRetornoGrupo, RetornoGrupoUsuario.gr_codigo == RegistroRetornoGrupo.cod_grupo)
+            .where(
+                RetornoGrupoUsuario.us_codigo == usuario_id,
+                RegistroRetornoGrupo.retorno == retorno_id
+            )
+        )
+        result = await self.db.execute(stmt)
+        retorno_grupo_usuario = result.scalars().first()
+        return retorno_grupo_usuario.grupo if retorno_grupo_usuario else None
+       

--- a/app/retornos/repositorios/retorno_repositorio.py
+++ b/app/retornos/repositorios/retorno_repositorio.py
@@ -62,3 +62,8 @@ class RetornoRepository:
         """Obtiene el retorno más reciente basado en el año."""
         result = await self.db.execute(select(Retorno).order_by(Retorno.anio.desc()).limit(1))
         return result.scalars().first()
+    
+    async def obtener_retorno_por_estado(self, estado: RetornoEstado) -> list[Retorno]:
+        """Obtiene todos los retornos que coincidan con un estado específico."""
+        result = await self.db.execute(select(Retorno).filter(Retorno.estado == estado.value))
+        return list(result.scalars().all())

--- a/app/retornos/servicios/grupo_retorno_servicio.py
+++ b/app/retornos/servicios/grupo_retorno_servicio.py
@@ -4,7 +4,7 @@
 """
 
 from app.retornos.esquemas.solicitud_retorno_grupo_esquema import SolicitudRetornoGrupoLiderRespuesta, SolicitudRetornoGrupoRespuesta, SolicitudRetornoGrupoUsuarioRespuesta
-from app.retornos.excepciones.registro_retorno_excepciones import SolicitudGrupoRetornoEstadoInvalido, SolicitudGrupoRetornoNoExistente, UsuarioNoPerteneceAlaMismaColonia
+from app.retornos.excepciones.registro_retorno_excepciones import GrupoNoEncontrado, SolicitudGrupoRetornoEstadoInvalido, SolicitudGrupoRetornoNoExistente, UsuarioNoEstaEnUnGrupo, UsuarioNoPerteneceAlaMismaColonia
 from app.retornos.repositorios.grupo_retorno_repositorio import GrupoRetornoRepositorio
 from app.retornos.repositorios.retorno_grupo_usuario_repositorio import RetornoGrupoUsuarioRepositorio
 from app.retornos.repositorios.retorno_repositorio import RetornoRepository
@@ -204,4 +204,17 @@ class GrupoRetornoServicio:
 
     async def _rechazar_solicitudes_pendientes_por_usuario(self, usuario_id):
         await self.repositorio_solicitudes.rechazar_solicitudes_pendientes_por_usuario(usuario_id)
-        
+    
+    async def obtener_grupo_por_usuario_retorno(self, usuario_id: int, retorno_id: int) -> GrupoRetornoRespuesta | None:
+        grupo = await self.repositorio_usuario_grupo.obtener_grupo_por_usuario_retorno(usuario_id, retorno_id)
+        if grupo:
+            return GrupoRetornoRespuesta.model_validate(grupo)
+        raise UsuarioNoEstaEnUnGrupo(usuario_id, retorno_id)
+    
+    async def obtener_usuarios_por_grupo(self, gr_codigo: int) -> list[UsuarioSalida]:
+        grupo =  await self.repositorio_grupos.obtener_grupo_por_id(gr_codigo)
+        if not grupo:
+            raise GrupoNoEncontrado(gr_codigo)
+        usuarios = await self.repositorio_usuario_grupo.obtener_miembros_por_grupo(gr_codigo)
+        return [UsuarioSalida.model_validate(usuario) for usuario in usuarios]
+    

--- a/app/retornos/servicios/persona_servicio.py
+++ b/app/retornos/servicios/persona_servicio.py
@@ -81,5 +81,15 @@ class PersonaServicio:
         """Verifica si una persona está registrada para un retorno específico."""
         persona_grupo = await self.repositorio.persona_ya_en_retorno(pe_codigo, re_codigo)
         return bool(persona_grupo)
+    
+    async def verificar_registro_retorno_persona_por_documento(self, pe_documento: str, re_codigo: int) -> bool:
+        """Verifica si una persona está registrada para un retorno específico."""
+        persona = await self.repositorio.obtener_por_documento(pe_documento)
+        if not persona:
+            raise HTTPException(status_code=404, detail="Persona no encontrada.")
+        persona_grupo = await self.repositorio.persona_ya_en_retorno(persona.pe_codigo, re_codigo)
+        return bool(persona_grupo)
+    
+    
 
 

--- a/app/retornos/servicios/persona_servicio.py
+++ b/app/retornos/servicios/persona_servicio.py
@@ -76,3 +76,10 @@ class PersonaServicio:
         if not persona:
             raise HTTPException(status_code=404, detail="Persona no encontrada.")
         return PersonaRespuesta.model_validate(persona)
+    
+    async def verificar_registro_retorno_persona(self, pe_codigo: int, re_codigo: int) -> bool:
+        """Verifica si una persona está registrada para un retorno específico."""
+        persona_grupo = await self.repositorio.persona_ya_en_retorno(pe_codigo, re_codigo)
+        return bool(persona_grupo)
+
+

--- a/app/retornos/servicios/persona_servicio.py
+++ b/app/retornos/servicios/persona_servicio.py
@@ -60,3 +60,19 @@ class PersonaServicio:
     async def listar_personas_por_grupo(self, gr_codigo: int) -> List[PersonaRespuesta]:
         personas = await self.repositorio.obtener_personas_por_grupo(gr_codigo)
         return [PersonaRespuesta.model_validate(p) for p in personas]
+    
+    async def listar_personas(self) -> List[PersonaRespuesta]:
+        personas = await self.repositorio.obtener_todas_las_personas()
+        return [PersonaRespuesta.model_validate(p) for p in personas]
+    
+    async def obtener_persona_por_id(self, pe_codigo: int) -> PersonaRespuesta|None:
+        persona = await self.repositorio.obtener_por_id(pe_codigo)
+        if not persona:
+            raise HTTPException(status_code=404, detail="Persona no encontrada.")
+        return PersonaRespuesta.model_validate(persona)
+    
+    async def obtener_persona_por_documento(self, documento: str) -> PersonaRespuesta|None:
+        persona = await self.repositorio.obtener_por_documento(documento)
+        if not persona:
+            raise HTTPException(status_code=404, detail="Persona no encontrada.")
+        return PersonaRespuesta.model_validate(persona)

--- a/app/retornos/servicios/registro_retorno_grupo_servicio.py
+++ b/app/retornos/servicios/registro_retorno_grupo_servicio.py
@@ -99,7 +99,7 @@ class RegistroRetornoGrupoServicio:
         await self.repositorio_usuario_grupo.asociar_usuario_a_grupo_retorno(grupo.us_codigo_lider, datos.cod_grupo)
         return RegistroRetornoGrupoRespuesta.model_validate(registro)
 
-    async def obtener_usuarios_por_grupo(self, gr_codigo: int) -> list[UsuarioSalida]:
+    async def obtener_miembros_por_grupo(self, gr_codigo: int) -> list[UsuarioSalida]:
         """
         Retorna la lista completa de integrantes de un grupo, incluyendo al líder,
         usuarios adicionales y personas (asistentes no usuarios).
@@ -111,19 +111,15 @@ class RegistroRetornoGrupoServicio:
                 detail=f"El grupo con código {gr_codigo} no existe."
             )
         
-        # 1. Obtener los datos del líder
-        lider = await self.repositorio_grupo.obtener_lider_por_grupo_id(gr_codigo)
+    
         
-        # 2. Obtener usuarios miembros (invitados que aceptaron)
+        # 1. Obtener usuarios miembros (invitados que aceptaron)
         miembros_usuarios = await self.repositorio_usuario_grupo.obtener_miembros_por_grupo(gr_codigo)
         
-        # 3. Obtener personas (asistentes adicionales no registrados como usuarios)
+        # 2. Obtener personas (asistentes adicionales no registrados como usuarios)
         personas = await self.repositorio_persona.obtener_personas_por_grupo(gr_codigo)
         
         resultado: list[UsuarioSalida] = []
-        
-        if lider:
-            resultado.append(UsuarioSalida.model_validate(lider))
             
         for m in miembros_usuarios:
             resultado.append(UsuarioSalida.model_validate(m))

--- a/app/retornos/servicios/retorno_servicio.py
+++ b/app/retornos/servicios/retorno_servicio.py
@@ -15,6 +15,7 @@ from app.retornos.excepciones.retorno_excepciones import (
     RetornoNotFoundError,
     RetornoAnioDuplicadoError,
     RetornoAnioPasadoError,
+    RetornoVigenteError,
 )
 import datetime
 
@@ -37,6 +38,11 @@ class RetornoService:
         if existente:
             raise RetornoAnioDuplicadoError(data.anio)
 
+        # Restricción 3: solo puede haber un retorno activo o en curso a la vez
+        retornos_vigentes = await self.repo.obtener_retorno_por_estado(RetornoEstado.ACTIVO) + await self.repo.obtener_retorno_por_estado(RetornoEstado.EN_CURSO)
+        if data.estado != RetornoEstado.FINALIZADO and retornos_vigentes:
+            raise RetornoVigenteError()
+        
         retorno = await self.repo.create(data)
         return RetornoResponse.model_validate(retorno)
 
@@ -58,9 +64,6 @@ class RetornoService:
         retorno = await self.repo.get_by_codigo(codigo)
         if not retorno:
             raise RetornoNotFoundError(codigo)
-        
         RetornoEstadoTransicion.validar_transicion(retorno.estado, nuevo_estado)
-        
         retorno_actualizado = await self.repo.cambiar_estado_retorno(codigo, nuevo_estado)
-        
         return RetornoResponse.model_validate(retorno_actualizado)

--- a/app/retornos/servicios/retorno_servicio.py
+++ b/app/retornos/servicios/retorno_servicio.py
@@ -46,6 +46,17 @@ class RetornoService:
         retorno = await self.repo.create(data)
         return RetornoResponse.model_validate(retorno)
 
+    async def obtener_retorno_vigente(self) -> RetornoResponse | None:
+        """Obtiene el retorno vigente, si existe alguno."""
+        retornos_activos = await self.repo.obtener_retorno_por_estado(RetornoEstado.ACTIVO)
+        if retornos_activos:
+            return RetornoResponse.model_validate(retornos_activos[0])
+        
+        retornos_en_curso = await self.repo.obtener_retorno_por_estado(RetornoEstado.EN_CURSO)
+        if retornos_en_curso:
+            return RetornoResponse.model_validate(retornos_en_curso[0])
+        
+        return None
     async def listar_retornos(self) -> list[RetornoResponse]:
         """Retorna todos los retornos registrados."""
         retornos = await self.repo.get_all()

--- a/app/retornos/servicios/retorno_servicio.py
+++ b/app/retornos/servicios/retorno_servicio.py
@@ -16,6 +16,7 @@ from app.retornos.excepciones.retorno_excepciones import (
     RetornoAnioDuplicadoError,
     RetornoAnioPasadoError,
     RetornoVigenteError,
+    NoHayRetornoVigenteError
 )
 import datetime
 
@@ -56,7 +57,7 @@ class RetornoService:
         if retornos_en_curso:
             return RetornoResponse.model_validate(retornos_en_curso[0])
         
-        return None
+        raise  NoHayRetornoVigenteError()
     async def listar_retornos(self) -> list[RetornoResponse]:
         """Retorna todos los retornos registrados."""
         retornos = await self.repo.get_all()


### PR DESCRIPTION
## Descripción del Cambio
Esta PR posee:
- validaciones para que solo exista un retorno vigente
- endpoint para obtener el retorno vigente
- endpoint para extraer el grupo al que pertenece un usuario con su id
- endpoint para listar los USUARIOS de un grupo de retorno 
- endpoints para ver si una persona esta registrado en un retorno mediante id y documento 
- Cambio en la logica de como se obtienen los miembros de un grupo (incluye a personas y usuarios)
## ID de la Historia de Usuario
- Estas funcionalidades surgieron durante el proceso de integración, así que no tienen código de HU asignadas.  

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [x] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%?
- [x] ¿Las validaciones de negocio (Documento > 0, Celular 10 dígitos, etc.) están implementadas?

## ¿Cómo probar este cambio?
**Backend:**
1. Levantar con Docker.
2. Probar en Swagger los siguientes endpoints:
/api/v1/retornos/vigente
/api/v1/grupoRetorno/{gr_codigo}/miembros
/api/v1/grupoRetorno/grupo/usuario/{usuario_id}/{retorno_id}
/api/v1/grupoRetorno/grupo/usuarios/{gr_codigo}/
/api/v1/personas/registro-documento/{pe_documento}/{re_codigo}
/api/v1/personas/registro-id/{pe_codigo}/{re_codigo}