### PR TITLE
feat(consultar-registro-grupo): Consultar registros de un grupo de retorno en un retorno específico

### DIFF
--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -391,4 +391,40 @@ async def obtener_grupo_por_usuario(usuario_id: int, retorno_id: int, servicio: 
 async def obtener_usuarios_por_grupo(gr_codigo: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
     return await servicio.obtener_usuarios_por_grupo(gr_codigo)
 
-    
+@grupo_retorno_router.get(
+    "/registro/{gr_codigo}/{re_codigo}",
+    response_model=RegistroRetornoGrupoRespuesta,
+    status_code=status.HTTP_200_OK,
+    summary="Obtener registro de grupo de retorno por grupo y retorno",
+    description="Obtiene el registro de un grupo en un retorno específico.",
+    responses = {
+        200: {
+            "description": "Registro encontrado exitosamente.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "regg_codigo": 1,
+                        "retorno": 1,
+                        "cod_grupo": 1,
+                        "num_hospedaje": 2,
+                        "num_transporte": 1,
+                        "num_parqueadero_carro": 1,
+                        "anotacion": "Necesidades especiales de hospedaje"
+                    }
+                }
+            }
+        },
+        404: {
+            "description": "No se encontró un registro para el grupo y retorno especificados.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "detail": "No se encontró un registro para el grupo 123 en el retorno 456."
+                    }
+                }
+            },
+        },
+    },
+)
+async def obtener_registro_por_grupo_y_retorno(gr_codigo: int, re_codigo: int, servicio: RegistroRetornoGrupoServicio = Depends(obtener_registro_retorno_grupo_servicio)):
+    return await servicio.consultar_registro_por_grupo_y_retorno(gr_codigo, re_codigo)

--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -174,7 +174,7 @@ async def obtener_retorno(codigo: int, servicio: Annotated[RetornoService, Depen
         },
     }
 )
-async def cambiar_estado_retorno(codigo: int, nuevo_estado: CambiarEstadoRetorno, db: AsyncSession = Depends(get_db)):
+async def cambiar_estado_retorno(codigo: int, nuevo_estado: CambiarEstadoRetorno, db: Annotated[AsyncSession, Depends(get_db)]):
     service = RetornoService(db)
     return await service.cambiar_estado_retorno(codigo, nuevo_estado.estado)
 
@@ -347,7 +347,7 @@ async def obtener_miembros_grupo_endpoint(
               summary="Aceptar solicitud de grupo de retorno", 
               description="Acepta una solicitud pendiente para unirse a un grupo de retorno específico. " \
               "Cambia el estado de la solicitud a aceptada y agrega al usuario al grupo.")
-async def aceptar_solicitud_grupo_retorno(solicitud_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def aceptar_solicitud_grupo_retorno(solicitud_id: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.aceptar_solicitud_grupo_retorno(solicitud_id)
 
 @grupo_retorno_router.patch("/solicitudes/rechazar/{solicitud_id}", 
@@ -356,7 +356,7 @@ async def aceptar_solicitud_grupo_retorno(solicitud_id: int, servicio: GrupoReto
               summary="Rechazar solicitud de grupo de retorno", 
               description="Rechaza una solicitud pendiente para unirse a un grupo de retorno específico. " \
               "Cambia el estado de la solicitud a rechazada.")
-async def rechazar_solicitud_grupo_retorno(solicitud_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def rechazar_solicitud_grupo_retorno(solicitud_id: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.rechazar_solicitud_grupo_retorno(solicitud_id)
 
 @grupo_retorno_router.get("/solicitudes/recientes/usuario/{usuario_id}",
@@ -364,7 +364,7 @@ async def rechazar_solicitud_grupo_retorno(solicitud_id: int, servicio: GrupoRet
             status_code=status.HTTP_200_OK,
             summary="Obtener solicitudes de grupos de retorno por usuario",
             description="Obtiene las solicitudes de ingreso a grupos de retorno recientes (ultimos 30 días) dirigidas a un usuario específico, ordenadas por fecha de creación más reciente primero.")
-async def obtener_solicitudes_recientes_grupo_por_usuario(usuario_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def obtener_solicitudes_recientes_grupo_por_usuario(usuario_id: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.obtener_solicitudes_recientes_por_usuario(usuario_id)
 
 @grupo_retorno_router.get("/solicitudes/grupo/{grupo_retorno_id}",
@@ -372,7 +372,7 @@ async def obtener_solicitudes_recientes_grupo_por_usuario(usuario_id: int, servi
             status_code=status.HTTP_200_OK,
             summary="Obtener solicitudes de grupos de retorno por grupo de retorno",
             description="Obtiene las solicitudes de ingreso a grupos de retorno enviadas por el lider del grupo.")
-async def obtener_solicitudes_grupo_por_lider(grupo_retorno_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def obtener_solicitudes_grupo_por_lider(grupo_retorno_id: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.obtener_solicitudes_por_grupo_retorno(grupo_retorno_id)
 
 @grupo_retorno_router.get("/grupo/usuario/{usuario_id}/{retorno_id}",    
@@ -380,7 +380,7 @@ async def obtener_solicitudes_grupo_por_lider(grupo_retorno_id: int, servicio: G
                           status_code=status.HTTP_200_OK,
                             summary="Obtener grupo de retorno por usuario",
                             description="Obtiene el grupo de retorno al que pertenece un usuario específico.")
-async def obtener_grupo_por_usuario(usuario_id: int, retorno_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def obtener_grupo_por_usuario(usuario_id: int, retorno_id: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.obtener_grupo_por_usuario_retorno(usuario_id, retorno_id)
 
 @grupo_retorno_router.get("/grupo/usuarios/{gr_codigo}/",
@@ -388,7 +388,7 @@ async def obtener_grupo_por_usuario(usuario_id: int, retorno_id: int, servicio: 
                             status_code=status.HTTP_200_OK,
                                 summary="Obtener usuarios por grupo de retorno",
                                 description="Obtiene la lista de usuarios que pertenecen a un grupo de retorno específico.")
-async def obtener_usuarios_por_grupo(gr_codigo: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def obtener_usuarios_por_grupo(gr_codigo: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.obtener_usuarios_por_grupo(gr_codigo)
 
 @grupo_retorno_router.get(
@@ -426,5 +426,5 @@ async def obtener_usuarios_por_grupo(gr_codigo: int, servicio: GrupoRetornoServi
         },
     },
 )
-async def obtener_registro_por_grupo_y_retorno(gr_codigo: int, re_codigo: int, servicio: RegistroRetornoGrupoServicio = Depends(obtener_registro_retorno_grupo_servicio)):
+async def obtener_registro_por_grupo_y_retorno(gr_codigo: int, re_codigo: int, servicio: Annotated[RegistroRetornoGrupoServicio, Depends(obtener_registro_retorno_grupo_servicio)]):
     return await servicio.consultar_registro_por_grupo_y_retorno(gr_codigo, re_codigo)

--- a/app/retornos/excepciones/registro_retorno_grupo_excepciones.py
+++ b/app/retornos/excepciones/registro_retorno_grupo_excepciones.py
@@ -19,3 +19,17 @@ class RetornoNoActivo(HTTPException):
             status_code=status.HTTP_409_CONFLICT,
             detail=f"No es posible incribirse en el retorno con código {retorno_id} porque su estado es {retorno_estado}."
         )
+
+class RegistroGrupoRetornoNoExistente(HTTPException):
+    def __init__(self, grupo_id: int, retorno_id: int):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No existe un registro para el grupo con código {grupo_id} en el retorno con código {retorno_id}."
+        )
+
+class GrupoRetornoNoExistente(HTTPException):
+    def __init__(self, grupo_id: int):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"El grupo con código {grupo_id} no existe."
+        )

--- a/app/retornos/servicios/registro_retorno_grupo_servicio.py
+++ b/app/retornos/servicios/registro_retorno_grupo_servicio.py
@@ -10,7 +10,12 @@ from app.retornos.repositorios.retorno_repositorio import RetornoRepository
 from app.retornos.repositorios.persona_repositorio import PersonaRepositorio
 from app.retornos.repositorios.retorno_grupo_usuario_repositorio import RetornoGrupoUsuarioRepositorio
 from app.usuarios.schemas.usuario_esquemas import UsuarioSalida
-from app.retornos.excepciones.registro_retorno_grupo_excepciones import RetornoNoExistente, RetornoNoActivo
+from app.retornos.excepciones.registro_retorno_grupo_excepciones import (
+    RetornoNoExistente, 
+    RetornoNoActivo, 
+    RegistroGrupoRetornoNoExistente,
+    GrupoRetornoNoExistente
+)
 
 class RegistroRetornoGrupoServicio: 
     def __init__(
@@ -136,4 +141,26 @@ class RegistroRetornoGrupoServicio:
             
         return resultado
 
-    
+    async def consultar_registro_por_grupo_y_retorno(self, gr_codigo: int, re_codigo: int) -> RegistroRetornoGrupoRespuesta:
+        """
+        Consulta el registro de un grupo en un retorno específico.
+        Parámetros:
+            gr_codigo: Código del grupo a consultar.
+            re_codigo: Código del retorno a consultar.
+        Retorna:
+            RegistroRetornoGrupoRespuesta con los detalles del registro encontrado.
+        Excepciones:
+            HTTPException 404: Si el grupo o el retorno no existen, o si no hay un registro para ese grupo en ese retorno.
+        """
+        retorno = await self.repositorio_retorno.get_by_codigo(re_codigo)
+        if not retorno:
+            raise RetornoNoExistente(re_codigo)
+        
+        grupo = await self.repositorio_grupo.obtener_grupo_por_id(gr_codigo)
+        if not grupo:
+            raise GrupoRetornoNoExistente(gr_codigo)
+        
+        registro = await self.repositorio_registro_grupo.obtener_registro_por_grupo_y_retorno(gr_codigo, re_codigo)
+        if not registro:
+            raise RegistroGrupoRetornoNoExistente(gr_codigo, re_codigo)
+        return RegistroRetornoGrupoRespuesta.model_validate(registro)

--- a/tests/retornos/test_registro_retorno_grupo_servicio.py
+++ b/tests/retornos/test_registro_retorno_grupo_servicio.py
@@ -43,17 +43,17 @@ def datos_crear():
 @pytest.mark.asyncio
 async def test_crear_registro_grupo_exito(servicio, mocks, datos_crear):
     """Caso de éxito: El grupo cumple todas las condiciones y se registra."""
-    # Setup: El grupo existe, el retorno coincide, tiene miembros y no está duplicado
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1))
-    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=1)
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[]) # No personas para este test
-    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None) 
+    mock_grupo = MagicMock(us_codigo_lider=1)
+    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=mock_grupo)
+    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
+    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=2)  # 2 usuarios adicionales
+    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[])
+    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None)
+    mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno = AsyncMock()
     
     mock_entidad = MagicMock()
     mocks["repo_reg"].crear_registro_grupo_retorno = AsyncMock(return_value=mock_entidad)
 
-    # Mockeamos la validación del esquema para evitar dependencias de mapeo de nombres en el test
     with patch.object(RegistroRetornoGrupoRespuesta, 'model_validate') as mock_validate:
         mock_validate.return_value = MagicMock(regg_codigo=100)
         
@@ -61,6 +61,7 @@ async def test_crear_registro_grupo_exito(servicio, mocks, datos_crear):
         
         assert resultado.regg_codigo == 100
         mocks["repo_reg"].crear_registro_grupo_retorno.assert_called_once_with(datos_crear)
+        mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno.assert_called_once_with(1, datos_crear.cod_grupo)
 
 @pytest.mark.asyncio
 async def test_crear_registro_grupo_no_existe(servicio, mocks, datos_crear):
@@ -88,17 +89,20 @@ async def test_crear_registro_retorno_no_vigente(servicio, mocks, datos_crear):
 
 @pytest.mark.asyncio
 async def test_crear_registro_sin_integrantes_suficientes(servicio, mocks, datos_crear):
-    """Error: El grupo no tiene miembros adicionales al líder (400)."""
+    """Error: El grupo no tiene suficientes integrantes para los servicios solicitados (400)."""
     mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1))
-    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=0) # No usuarios adicionales
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[]) # No personas
+    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
+    # Solo 1 integrante total (0 usuarios + 0 personas + 1 líder)
+    # pero datos_crear solicita 2 hospedajes, esto debe fallar
+    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=0)
+    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[])
 
     with pytest.raises(HTTPException) as exc:
         await servicio.crear_registro_retorno_grupo(datos_crear)
     
     assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
-    assert "al menos un integrante (usuario o persona)" in exc.value.detail # Mensaje de error actualizado
+    # El error será por hospedajes, no por integrantes mínimos
+    assert "hospedajes" in exc.value.detail
 
 @pytest.mark.asyncio
 async def test_crear_registro_duplicado(servicio, mocks, datos_crear):
@@ -116,33 +120,38 @@ async def test_crear_registro_duplicado(servicio, mocks, datos_crear):
     assert exc.value.status_code == status.HTTP_409_CONFLICT
 
 @pytest.mark.asyncio
-async def test_obtener_usuarios_por_grupo_exito(servicio, mocks):
-    """Caso de éxito: Se recuperan los miembros de un grupo existente."""
+async def test_obtener_miembros_por_grupo_exito(servicio, mocks):
+    """Caso de éxito: Se recuperan todos los miembros de un grupo (usuarios + personas)."""
     mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    mocks["repo_grupo"].obtener_lider_por_grupo_id = AsyncMock(return_value=MagicMock())
-    mocks["repo_usuario_grupo"].obtener_miembros_por_grupo = AsyncMock(return_value=[MagicMock(), MagicMock()])
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[])
+    mock_miembro1 = MagicMock()
+    mock_miembro2 = MagicMock()
+    mocks["repo_usuario_grupo"].obtener_miembros_por_grupo = AsyncMock(return_value=[mock_miembro1, mock_miembro2])
+    mock_persona = MagicMock(pe_codigo=1, pe_nombre="Juan", pe_apellido="Pérez", pe_correo="juan@test.com", pe_documento="123456")
+    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[mock_persona])
 
     with patch.object(UsuarioSalida, 'model_validate', return_value=MagicMock()):
-        resultado = await servicio.obtener_usuarios_por_grupo(10)
+        resultado = await servicio.obtener_miembros_por_grupo(10)
+        # 2 usuarios miembros + 1 persona = 3 total
         assert len(resultado) == 3
-        mocks["repo_grupo"].obtener_lider_por_grupo_id.assert_called_once_with(10)
+        mocks["repo_grupo"].obtener_grupo_por_id.assert_called_once_with(10)
         mocks["repo_usuario_grupo"].obtener_miembros_por_grupo.assert_called_once_with(10)
+        mocks["repo_persona"].obtener_personas_por_grupo.assert_called_once_with(10)
 
 @pytest.mark.asyncio
 async def test_crear_registro_grupo_solo_personas(servicio, mocks, datos_crear):
     """Caso de éxito: El grupo tiene personas pero no usuarios adicionales al líder."""
-    # Setup: El grupo existe, el retorno coincide, tiene miembros y no está duplicado
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1))
-    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=0) # No usuarios adicionales
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[MagicMock()]) # Una persona
+    mock_grupo = MagicMock(us_codigo_lider=1)
+    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=mock_grupo)
+    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
+    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=0)
+    # 2 personas = 0 + 2 + 1 (líder) = 3 integrantes total (suficiente para los servicios solicitados)
+    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[MagicMock(), MagicMock()])
     mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None)
+    mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno = AsyncMock()
     
     mock_entidad = MagicMock()
     mocks["repo_reg"].crear_registro_grupo_retorno = AsyncMock(return_value=mock_entidad)
 
-    # Mockeamos la validación del esquema para evitar dependencias de mapeo de nombres en el test
     with patch.object(RegistroRetornoGrupoRespuesta, 'model_validate') as mock_validate:
         mock_validate.return_value = MagicMock(regg_codigo=100)
         
@@ -154,11 +163,14 @@ async def test_crear_registro_grupo_solo_personas(servicio, mocks, datos_crear):
 @pytest.mark.asyncio
 async def test_crear_registro_grupo_usuarios_y_personas(servicio, mocks, datos_crear):
     """Caso de éxito: El grupo tiene usuarios adicionales y personas."""
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1))
-    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=1) # Un usuario adicional
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[MagicMock(), MagicMock()]) # Dos personas
+    mock_grupo = MagicMock(us_codigo_lider=1)
+    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=mock_grupo)
+    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
+    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=1)  # 1 usuario adicional
+    # 1 usuario + 2 personas + 1 (líder) = 4 integrantes (más que suficiente)
+    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[MagicMock(), MagicMock()])
     mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None)
+    mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno = AsyncMock()
     
     mock_entidad = MagicMock()
     mocks["repo_reg"].crear_registro_grupo_retorno = AsyncMock(return_value=mock_entidad)
@@ -170,3 +182,54 @@ async def test_crear_registro_grupo_usuarios_y_personas(servicio, mocks, datos_c
         
         assert resultado.regg_codigo == 100
         mocks["repo_reg"].crear_registro_grupo_retorno.assert_called_once_with(datos_crear)
+
+@pytest.mark.asyncio
+async def test_consultar_registro_exito(servicio, mocks):
+    """Caso de éxito: Se consulta un registro existente de un grupo en un retorno."""
+    mocks["repo_retorno"].get_by_codigo = AsyncMock(return_value=MagicMock())
+    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
+    mock_registro = MagicMock()
+    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=mock_registro)
+
+    with patch.object(RegistroRetornoGrupoRespuesta, 'model_validate') as mock_validate:
+        mock_validate.return_value = MagicMock(regg_codigo=100)
+        
+        resultado = await servicio.consultar_registro_por_grupo_y_retorno(10, 1)
+        
+        assert resultado.regg_codigo == 100
+        mocks["repo_retorno"].get_by_codigo.assert_called_once_with(1)
+        mocks["repo_grupo"].obtener_grupo_por_id.assert_called_once_with(10)
+        mocks["repo_reg"].obtener_registro_por_grupo_y_retorno.assert_called_once_with(10, 1)
+
+@pytest.mark.asyncio
+async def test_consultar_registro_retorno_no_existe(servicio, mocks):
+    """Error: Se intenta consultar un registro para un retorno que no existe (404)."""
+    mocks["repo_retorno"].get_by_codigo = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await servicio.consultar_registro_por_grupo_y_retorno(10, 999)
+    
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+
+@pytest.mark.asyncio
+async def test_consultar_registro_grupo_no_existe(servicio, mocks):
+    """Error: Se intenta consultar un registro para un grupo que no existe (404)."""
+    mocks["repo_retorno"].get_by_codigo = AsyncMock(return_value=MagicMock())
+    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await servicio.consultar_registro_por_grupo_y_retorno(999, 1)
+    
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+
+@pytest.mark.asyncio
+async def test_consultar_registro_no_existe_para_grupo_y_retorno(servicio, mocks):
+    """Error: No existe un registro para la combinación de grupo y retorno especificada (404)."""
+    mocks["repo_retorno"].get_by_codigo = AsyncMock(return_value=MagicMock())
+    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
+    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await servicio.consultar_registro_por_grupo_y_retorno(10, 1)
+    
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/retornos/test_registro_retorno_grupo_servicio.py
+++ b/tests/retornos/test_registro_retorno_grupo_servicio.py
@@ -40,13 +40,15 @@ def datos_crear():
         anotacion="Prueba de registro de grupo"
     )
 
+# ===== PRUEBAS: crear_registro_retorno_grupo =====
+
 @pytest.mark.asyncio
 async def test_crear_registro_grupo_exito(servicio, mocks, datos_crear):
     """Caso de éxito: El grupo cumple todas las condiciones y se registra."""
     mock_grupo = MagicMock(us_codigo_lider=1)
     mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=mock_grupo)
     mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
-    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=2)  # 2 usuarios adicionales
+    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=2)
     mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[])
     mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None)
     mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno = AsyncMock()
@@ -78,7 +80,6 @@ async def test_crear_registro_grupo_no_existe(servicio, mocks, datos_crear):
 async def test_crear_registro_retorno_no_vigente(servicio, mocks, datos_crear):
     """Error: Se intenta registrar en un retorno que no es el último vigente (400)."""
     mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    # El último en el sistema es el 2, pero los datos piden el 1
     mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=2))
 
     with pytest.raises(HTTPException) as exc:
@@ -92,8 +93,6 @@ async def test_crear_registro_sin_integrantes_suficientes(servicio, mocks, datos
     """Error: El grupo no tiene suficientes integrantes para los servicios solicitados (400)."""
     mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
     mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
-    # Solo 1 integrante total (0 usuarios + 0 personas + 1 líder)
-    # pero datos_crear solicita 2 hospedajes, esto debe fallar
     mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=0)
     mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[])
 
@@ -101,17 +100,15 @@ async def test_crear_registro_sin_integrantes_suficientes(servicio, mocks, datos
         await servicio.crear_registro_retorno_grupo(datos_crear)
     
     assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
-    # El error será por hospedajes, no por integrantes mínimos
     assert "hospedajes" in exc.value.detail
 
 @pytest.mark.asyncio
 async def test_crear_registro_duplicado(servicio, mocks, datos_crear):
     """Error: El grupo ya fue registrado previamente para este retorno (409)."""
     mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1))
+    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
     mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=2)
-    # El repo devuelve que ya existe un registro
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[]) # No personas para este test
+    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[])
     mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=MagicMock())
 
     with pytest.raises(HTTPException) as exc:
@@ -120,31 +117,12 @@ async def test_crear_registro_duplicado(servicio, mocks, datos_crear):
     assert exc.value.status_code == status.HTTP_409_CONFLICT
 
 @pytest.mark.asyncio
-async def test_obtener_miembros_por_grupo_exito(servicio, mocks):
-    """Caso de éxito: Se recuperan todos los miembros de un grupo (usuarios + personas)."""
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    mock_miembro1 = MagicMock()
-    mock_miembro2 = MagicMock()
-    mocks["repo_usuario_grupo"].obtener_miembros_por_grupo = AsyncMock(return_value=[mock_miembro1, mock_miembro2])
-    mock_persona = MagicMock(pe_codigo=1, pe_nombre="Juan", pe_apellido="Pérez", pe_correo="juan@test.com", pe_documento="123456")
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[mock_persona])
-
-    with patch.object(UsuarioSalida, 'model_validate', return_value=MagicMock()):
-        resultado = await servicio.obtener_miembros_por_grupo(10)
-        # 2 usuarios miembros + 1 persona = 3 total
-        assert len(resultado) == 3
-        mocks["repo_grupo"].obtener_grupo_por_id.assert_called_once_with(10)
-        mocks["repo_usuario_grupo"].obtener_miembros_por_grupo.assert_called_once_with(10)
-        mocks["repo_persona"].obtener_personas_por_grupo.assert_called_once_with(10)
-
-@pytest.mark.asyncio
 async def test_crear_registro_grupo_solo_personas(servicio, mocks, datos_crear):
     """Caso de éxito: El grupo tiene personas pero no usuarios adicionales al líder."""
     mock_grupo = MagicMock(us_codigo_lider=1)
     mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=mock_grupo)
     mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
     mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=0)
-    # 2 personas = 0 + 2 + 1 (líder) = 3 integrantes total (suficiente para los servicios solicitados)
     mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[MagicMock(), MagicMock()])
     mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None)
     mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno = AsyncMock()
@@ -166,8 +144,7 @@ async def test_crear_registro_grupo_usuarios_y_personas(servicio, mocks, datos_c
     mock_grupo = MagicMock(us_codigo_lider=1)
     mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=mock_grupo)
     mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
-    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=1)  # 1 usuario adicional
-    # 1 usuario + 2 personas + 1 (líder) = 4 integrantes (más que suficiente)
+    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=1)
     mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[MagicMock(), MagicMock()])
     mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None)
     mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno = AsyncMock()
@@ -182,6 +159,27 @@ async def test_crear_registro_grupo_usuarios_y_personas(servicio, mocks, datos_c
         
         assert resultado.regg_codigo == 100
         mocks["repo_reg"].crear_registro_grupo_retorno.assert_called_once_with(datos_crear)
+
+# ===== PRUEBAS: obtener_miembros_por_grupo =====
+
+@pytest.mark.asyncio
+async def test_obtener_miembros_por_grupo_exito(servicio, mocks):
+    """Caso de éxito: Se recuperan todos los miembros de un grupo (usuarios + personas)."""
+    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
+    mock_miembro1 = MagicMock()
+    mock_miembro2 = MagicMock()
+    mocks["repo_usuario_grupo"].obtener_miembros_por_grupo = AsyncMock(return_value=[mock_miembro1, mock_miembro2])
+    mock_persona = MagicMock(pe_codigo=1, pe_nombre="Juan", pe_apellido="Pérez", pe_correo="juan@test.com", pe_documento="123456")
+    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[mock_persona])
+
+    with patch.object(UsuarioSalida, 'model_validate', return_value=MagicMock()):
+        resultado = await servicio.obtener_miembros_por_grupo(10)
+        assert len(resultado) == 3
+        mocks["repo_grupo"].obtener_grupo_por_id.assert_called_once_with(10)
+        mocks["repo_usuario_grupo"].obtener_miembros_por_grupo.assert_called_once_with(10)
+        mocks["repo_persona"].obtener_personas_por_grupo.assert_called_once_with(10)
+
+# ===== PRUEBAS: consultar_registro_por_grupo_y_retorno =====
 
 @pytest.mark.asyncio
 async def test_consultar_registro_exito(servicio, mocks):

--- a/tests/retornos/test_registro_retorno_grupo_servicio.py
+++ b/tests/retornos/test_registro_retorno_grupo_servicio.py
@@ -40,21 +40,46 @@ def datos_crear():
         anotacion="Prueba de registro de grupo"
     )
 
+# ===== HELPERS =====
+
+def setup_crear_registro_mocks(mocks, grupo_lider=1, retorno_codigo=1, retorno_estado="activo",
+                                usuarios_adicionales=2, personas=None, ya_registrado=False):
+    """Helper para configurar mocks comunes en pruebas de crear_registro_retorno_grupo."""
+    personas = personas or []
+    
+    mock_grupo = MagicMock(us_codigo_lider=grupo_lider)
+    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=mock_grupo)
+    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(
+        return_value=MagicMock(codigo=retorno_codigo, estado=retorno_estado)
+    )
+    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=usuarios_adicionales)
+    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=personas)
+    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(
+        return_value=MagicMock() if ya_registrado else None
+    )
+    mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno = AsyncMock()
+    
+    mock_entidad = MagicMock()
+    mocks["repo_reg"].crear_registro_grupo_retorno = AsyncMock(return_value=mock_entidad)
+
+def setup_consultar_registro_mocks(mocks, retorno_existe=True, grupo_existe=True, registro_existe=True):
+    """Helper para configurar mocks comunes en pruebas de consultar_registro_por_grupo_y_retorno."""
+    mocks["repo_retorno"].get_by_codigo = AsyncMock(
+        return_value=MagicMock() if retorno_existe else None
+    )
+    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(
+        return_value=MagicMock() if grupo_existe else None
+    )
+    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(
+        return_value=MagicMock() if registro_existe else None
+    )
+
 # ===== PRUEBAS: crear_registro_retorno_grupo =====
 
 @pytest.mark.asyncio
 async def test_crear_registro_grupo_exito(servicio, mocks, datos_crear):
     """Caso de éxito: El grupo cumple todas las condiciones y se registra."""
-    mock_grupo = MagicMock(us_codigo_lider=1)
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=mock_grupo)
-    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
-    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=2)
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[])
-    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None)
-    mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno = AsyncMock()
-    
-    mock_entidad = MagicMock()
-    mocks["repo_reg"].crear_registro_grupo_retorno = AsyncMock(return_value=mock_entidad)
+    setup_crear_registro_mocks(mocks)
 
     with patch.object(RegistroRetornoGrupoRespuesta, 'model_validate') as mock_validate:
         mock_validate.return_value = MagicMock(regg_codigo=100)
@@ -63,7 +88,6 @@ async def test_crear_registro_grupo_exito(servicio, mocks, datos_crear):
         
         assert resultado.regg_codigo == 100
         mocks["repo_reg"].crear_registro_grupo_retorno.assert_called_once_with(datos_crear)
-        mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno.assert_called_once_with(1, datos_crear.cod_grupo)
 
 @pytest.mark.asyncio
 async def test_crear_registro_grupo_no_existe(servicio, mocks, datos_crear):
@@ -91,10 +115,7 @@ async def test_crear_registro_retorno_no_vigente(servicio, mocks, datos_crear):
 @pytest.mark.asyncio
 async def test_crear_registro_sin_integrantes_suficientes(servicio, mocks, datos_crear):
     """Error: El grupo no tiene suficientes integrantes para los servicios solicitados (400)."""
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
-    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=0)
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[])
+    setup_crear_registro_mocks(mocks, usuarios_adicionales=0, personas=[])
 
     with pytest.raises(HTTPException) as exc:
         await servicio.crear_registro_retorno_grupo(datos_crear)
@@ -105,11 +126,7 @@ async def test_crear_registro_sin_integrantes_suficientes(servicio, mocks, datos
 @pytest.mark.asyncio
 async def test_crear_registro_duplicado(servicio, mocks, datos_crear):
     """Error: El grupo ya fue registrado previamente para este retorno (409)."""
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
-    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=2)
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[])
-    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=MagicMock())
+    setup_crear_registro_mocks(mocks, ya_registrado=True)
 
     with pytest.raises(HTTPException) as exc:
         await servicio.crear_registro_retorno_grupo(datos_crear)
@@ -119,16 +136,7 @@ async def test_crear_registro_duplicado(servicio, mocks, datos_crear):
 @pytest.mark.asyncio
 async def test_crear_registro_grupo_solo_personas(servicio, mocks, datos_crear):
     """Caso de éxito: El grupo tiene personas pero no usuarios adicionales al líder."""
-    mock_grupo = MagicMock(us_codigo_lider=1)
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=mock_grupo)
-    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
-    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=0)
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[MagicMock(), MagicMock()])
-    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None)
-    mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno = AsyncMock()
-    
-    mock_entidad = MagicMock()
-    mocks["repo_reg"].crear_registro_grupo_retorno = AsyncMock(return_value=mock_entidad)
+    setup_crear_registro_mocks(mocks, usuarios_adicionales=0, personas=[MagicMock(), MagicMock()])
 
     with patch.object(RegistroRetornoGrupoRespuesta, 'model_validate') as mock_validate:
         mock_validate.return_value = MagicMock(regg_codigo=100)
@@ -136,21 +144,11 @@ async def test_crear_registro_grupo_solo_personas(servicio, mocks, datos_crear):
         resultado = await servicio.crear_registro_retorno_grupo(datos_crear)
         
         assert resultado.regg_codigo == 100
-        mocks["repo_reg"].crear_registro_grupo_retorno.assert_called_once_with(datos_crear)
 
 @pytest.mark.asyncio
 async def test_crear_registro_grupo_usuarios_y_personas(servicio, mocks, datos_crear):
     """Caso de éxito: El grupo tiene usuarios adicionales y personas."""
-    mock_grupo = MagicMock(us_codigo_lider=1)
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=mock_grupo)
-    mocks["repo_retorno"].obtener_ultimo_retorno = AsyncMock(return_value=MagicMock(codigo=1, estado="activo"))
-    mocks["repo_usuario_grupo"].contar_miembros_adicionales = AsyncMock(return_value=1)
-    mocks["repo_persona"].obtener_personas_por_grupo = AsyncMock(return_value=[MagicMock(), MagicMock()])
-    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None)
-    mocks["repo_usuario_grupo"].asociar_usuario_a_grupo_retorno = AsyncMock()
-    
-    mock_entidad = MagicMock()
-    mocks["repo_reg"].crear_registro_grupo_retorno = AsyncMock(return_value=mock_entidad)
+    setup_crear_registro_mocks(mocks, usuarios_adicionales=1, personas=[MagicMock(), MagicMock()])
 
     with patch.object(RegistroRetornoGrupoRespuesta, 'model_validate') as mock_validate:
         mock_validate.return_value = MagicMock(regg_codigo=100)
@@ -158,7 +156,6 @@ async def test_crear_registro_grupo_usuarios_y_personas(servicio, mocks, datos_c
         resultado = await servicio.crear_registro_retorno_grupo(datos_crear)
         
         assert resultado.regg_codigo == 100
-        mocks["repo_reg"].crear_registro_grupo_retorno.assert_called_once_with(datos_crear)
 
 # ===== PRUEBAS: obtener_miembros_por_grupo =====
 
@@ -175,19 +172,13 @@ async def test_obtener_miembros_por_grupo_exito(servicio, mocks):
     with patch.object(UsuarioSalida, 'model_validate', return_value=MagicMock()):
         resultado = await servicio.obtener_miembros_por_grupo(10)
         assert len(resultado) == 3
-        mocks["repo_grupo"].obtener_grupo_por_id.assert_called_once_with(10)
-        mocks["repo_usuario_grupo"].obtener_miembros_por_grupo.assert_called_once_with(10)
-        mocks["repo_persona"].obtener_personas_por_grupo.assert_called_once_with(10)
 
 # ===== PRUEBAS: consultar_registro_por_grupo_y_retorno =====
 
 @pytest.mark.asyncio
 async def test_consultar_registro_exito(servicio, mocks):
     """Caso de éxito: Se consulta un registro existente de un grupo en un retorno."""
-    mocks["repo_retorno"].get_by_codigo = AsyncMock(return_value=MagicMock())
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    mock_registro = MagicMock()
-    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=mock_registro)
+    setup_consultar_registro_mocks(mocks)
 
     with patch.object(RegistroRetornoGrupoRespuesta, 'model_validate') as mock_validate:
         mock_validate.return_value = MagicMock(regg_codigo=100)
@@ -197,12 +188,11 @@ async def test_consultar_registro_exito(servicio, mocks):
         assert resultado.regg_codigo == 100
         mocks["repo_retorno"].get_by_codigo.assert_called_once_with(1)
         mocks["repo_grupo"].obtener_grupo_por_id.assert_called_once_with(10)
-        mocks["repo_reg"].obtener_registro_por_grupo_y_retorno.assert_called_once_with(10, 1)
 
 @pytest.mark.asyncio
 async def test_consultar_registro_retorno_no_existe(servicio, mocks):
     """Error: Se intenta consultar un registro para un retorno que no existe (404)."""
-    mocks["repo_retorno"].get_by_codigo = AsyncMock(return_value=None)
+    setup_consultar_registro_mocks(mocks, retorno_existe=False)
 
     with pytest.raises(HTTPException) as exc:
         await servicio.consultar_registro_por_grupo_y_retorno(10, 999)
@@ -212,8 +202,7 @@ async def test_consultar_registro_retorno_no_existe(servicio, mocks):
 @pytest.mark.asyncio
 async def test_consultar_registro_grupo_no_existe(servicio, mocks):
     """Error: Se intenta consultar un registro para un grupo que no existe (404)."""
-    mocks["repo_retorno"].get_by_codigo = AsyncMock(return_value=MagicMock())
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=None)
+    setup_consultar_registro_mocks(mocks, grupo_existe=False)
 
     with pytest.raises(HTTPException) as exc:
         await servicio.consultar_registro_por_grupo_y_retorno(999, 1)
@@ -223,9 +212,7 @@ async def test_consultar_registro_grupo_no_existe(servicio, mocks):
 @pytest.mark.asyncio
 async def test_consultar_registro_no_existe_para_grupo_y_retorno(servicio, mocks):
     """Error: No existe un registro para la combinación de grupo y retorno especificada (404)."""
-    mocks["repo_retorno"].get_by_codigo = AsyncMock(return_value=MagicMock())
-    mocks["repo_grupo"].obtener_grupo_por_id = AsyncMock(return_value=MagicMock())
-    mocks["repo_reg"].obtener_registro_por_grupo_y_retorno = AsyncMock(return_value=None)
+    setup_consultar_registro_mocks(mocks, registro_existe=False)
 
     with pytest.raises(HTTPException) as exc:
         await servicio.consultar_registro_por_grupo_y_retorno(10, 1)


### PR DESCRIPTION
## Descripción del Cambio
Se implementa la funcionalidad para consultar los registros asociados a un grupo de retorno dentro de un retorno específico.

### Cambios realizados
- Se agrega endpoint para obtener los registros de un grupo de retorno.
- Se implementa filtrado por retorno específico.
- Se agregan validaciones para verificar la existencia del retorno y del grupo de retorno.
- Se ajustan los servicios y repositorios relacionados con la consulta.
- Se documenta el endpoint en Swagger.

## ID de la Historia de Usuario
- **HU:**

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [x] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%?
- [x] ¿Las validaciones de negocio (Documento > 0, Celular 10 dígitos, etc.) están implementadas?

## ¿Cómo probar este cambio?

### Backend:
1. Levantar el proyecto con Docker.
2. Ingresar a Swagger (`/docs`).
3. Probar el endpoint de consulta de registros del grupo de retorno.
4. Ejemplo de parámetros:
-- Grupo de retorno: 1
-- Retorno: 1