### PR TITLE
feat(obtener-registro-usuario): Obtener datos de registro de un usuario a un retorno

### DIFF
--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -174,7 +174,7 @@ async def obtener_retorno(codigo: int, servicio: Annotated[RetornoService, Depen
         },
     }
 )
-async def cambiar_estado_retorno(codigo: int, nuevo_estado: CambiarEstadoRetorno, db: AsyncSession = Depends(get_db)):
+async def cambiar_estado_retorno(codigo: int, nuevo_estado: CambiarEstadoRetorno, db: Annotated[AsyncSession, Depends(get_db)]):
     service = RetornoService(db)
     return await service.cambiar_estado_retorno(codigo, nuevo_estado.estado)
 
@@ -355,7 +355,7 @@ async def obtener_miembros_grupo_endpoint(
               summary="Aceptar solicitud de grupo de retorno", 
               description="Acepta una solicitud pendiente para unirse a un grupo de retorno específico. " \
               "Cambia el estado de la solicitud a aceptada y agrega al usuario al grupo.")
-async def aceptar_solicitud_grupo_retorno(solicitud_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def aceptar_solicitud_grupo_retorno(solicitud_id: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.aceptar_solicitud_grupo_retorno(solicitud_id)
 
 @grupo_retorno_router.patch("/solicitudes/rechazar/{solicitud_id}", 
@@ -364,7 +364,7 @@ async def aceptar_solicitud_grupo_retorno(solicitud_id: int, servicio: GrupoReto
               summary="Rechazar solicitud de grupo de retorno", 
               description="Rechaza una solicitud pendiente para unirse a un grupo de retorno específico. " \
               "Cambia el estado de la solicitud a rechazada.")
-async def rechazar_solicitud_grupo_retorno(solicitud_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def rechazar_solicitud_grupo_retorno(solicitud_id: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.rechazar_solicitud_grupo_retorno(solicitud_id)
 
 @grupo_retorno_router.get("/solicitudes/recientes/usuario/{usuario_id}",
@@ -372,7 +372,7 @@ async def rechazar_solicitud_grupo_retorno(solicitud_id: int, servicio: GrupoRet
             status_code=status.HTTP_200_OK,
             summary="Obtener solicitudes de grupos de retorno por usuario",
             description="Obtiene las solicitudes de ingreso a grupos de retorno recientes (ultimos 30 días) dirigidas a un usuario específico, ordenadas por fecha de creación más reciente primero.")
-async def obtener_solicitudes_recientes_grupo_por_usuario(usuario_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def obtener_solicitudes_recientes_grupo_por_usuario(usuario_id: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.obtener_solicitudes_recientes_por_usuario(usuario_id)
 
 @grupo_retorno_router.get("/solicitudes/grupo/{grupo_retorno_id}",
@@ -380,7 +380,7 @@ async def obtener_solicitudes_recientes_grupo_por_usuario(usuario_id: int, servi
             status_code=status.HTTP_200_OK,
             summary="Obtener solicitudes de grupos de retorno por grupo de retorno",
             description="Obtiene las solicitudes de ingreso a grupos de retorno enviadas por el lider del grupo.")
-async def obtener_solicitudes_grupo_por_lider(grupo_retorno_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def obtener_solicitudes_grupo_por_lider(grupo_retorno_id: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.obtener_solicitudes_por_grupo_retorno(grupo_retorno_id)
 
 @grupo_retorno_router.get("/grupo/usuario/{usuario_id}/{retorno_id}",    
@@ -388,7 +388,7 @@ async def obtener_solicitudes_grupo_por_lider(grupo_retorno_id: int, servicio: G
                           status_code=status.HTTP_200_OK,
                             summary="Obtener grupo de retorno por usuario",
                             description="Obtiene el grupo de retorno al que pertenece un usuario específico.")
-async def obtener_grupo_por_usuario(usuario_id: int, retorno_id: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def obtener_grupo_por_usuario(usuario_id: int, retorno_id: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.obtener_grupo_por_usuario_retorno(usuario_id, retorno_id)
 
 @grupo_retorno_router.get("/grupo/usuarios/{gr_codigo}/",
@@ -396,7 +396,7 @@ async def obtener_grupo_por_usuario(usuario_id: int, retorno_id: int, servicio: 
                             status_code=status.HTTP_200_OK,
                                 summary="Obtener usuarios por grupo de retorno",
                                 description="Obtiene la lista de usuarios que pertenecen a un grupo de retorno específico.")
-async def obtener_usuarios_por_grupo(gr_codigo: int, servicio: GrupoRetornoServicio = Depends(obtener_grupo_retorno_servicio)):
+async def obtener_usuarios_por_grupo(gr_codigo: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
     return await servicio.obtener_usuarios_por_grupo(gr_codigo)
 
     

--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -201,6 +201,14 @@ async def cambiar_estado_retorno(codigo: int, nuevo_estado: CambiarEstadoRetorno
 async def inscribir_usuario_en_retorno(registro: RegistroRetornoCrear, servicio: Annotated[RegistroRetornoServicio, Depends(obtener_registro_retorno_servicio)]):
     return await servicio.crear_registro_retorno(registro)
 
+@router.get(
+    "/registro/usuario/{usuario_id}/retorno/{retorno_id}",
+    response_model=RegistroRetornoRespuesta | None,
+    summary="Obtener registro de retorno por usuario y retorno",
+    description="Busca y retorna el registro de participación de un usuario específico en un retorno determinado. Retorna None si no existe.",
+)
+async def obtener_registro_por_usuario_y_retorno(usuario_id: int, retorno_id: int, servicio: Annotated[RegistroRetornoServicio, Depends(obtener_registro_retorno_servicio)]):
+    return await servicio.obtener_registro_retorno_por_usuario_y_retorno(usuario_id, retorno_id)
 
 @router.delete(
     "/darse-de-baja",

--- a/app/retornos/servicios/registro_retorno_servicio.py
+++ b/app/retornos/servicios/registro_retorno_servicio.py
@@ -46,7 +46,7 @@ class RegistroRetornoServicio:
             - RegistroRetornoRespuesta: Esquema con los datos del registro de retorno creado.
         Excepciones:
             - RetornoNoExistente: Si el retorno especificado no existe.
-            - RetornoEstadoFinalizado: Si el retorno especificado ya ha finalizado.
+            - RetornoEstadoInvalido: Si el retorno especificado tiene un estado inválido.
             - UsuarioNoExistente: Si el usuario especificado no existe.
             - UsuarioSinColonia: Si el usuario especificado no pertenece a ninguna colonia.
             - UsuarioYaRegistrado: Si el usuario ya está registrado en el retorno especificado.

--- a/tests/retornos/test_registro_retorno.py
+++ b/tests/retornos/test_registro_retorno.py
@@ -1,5 +1,14 @@
-from unittest.mock import AsyncMock, MagicMock
-from app.retornos.excepciones.registro_retorno_excepciones import RetornoEstadoFinalizado, RetornoNoExistente, UsuarioNoExistente, UsuarioSinColonia, UsuarioYaRegistrado
+from unittest.mock import AsyncMock, MagicMock, patch
+from app.retornos.excepciones.registro_retorno_excepciones import (
+    RetornoNoExistente,
+    RetornoEstadoInvalido,
+    UsuarioNoExistente,
+    UsuarioSinColonia,
+    UsuarioYaRegistrado,
+    UsuarioNoRegistradoEnRetorno,
+    RegistroRetornoNoExistente
+)
+from app.retornos.excepciones.retorno_excepciones import RegistroIndividualParqueaderoExcedidoError
 import pytest
 
 from app.retornos.servicios.registro_retorno_servicio import RegistroRetornoServicio
@@ -9,6 +18,11 @@ def mock_repositorio():
     repositorio = MagicMock()
     repositorio.crear_registro_retorno = AsyncMock()
     repositorio.obtener_registro_retorno_por_usuario_y_retorno = AsyncMock()
+    repositorio.obtener_registro_retorno_por_id = AsyncMock()
+    repositorio.actualizar_registro_retorno = AsyncMock()
+    repositorio.eliminar_registro_retorno = AsyncMock()
+    repositorio.obtener_registros_retorno_por_usuario = AsyncMock()
+    repositorio.obtener_registros_retorno_activos_usuario = AsyncMock()
     return repositorio
 
 @pytest.fixture
@@ -31,8 +45,8 @@ def servicio(mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio):
 def retorno_mock():
     retorno = MagicMock()
     retorno.anio = 2026
-    retorno.estado = "activo"
-
+    retorno.estado = create_estado_mock("activo")
+    retorno.codigo = 1
     return retorno
 
 @pytest.fixture
@@ -50,95 +64,290 @@ def registro_retorno_mock():
     registro.re_codigo = 1
     return registro
 
+@pytest.fixture
+def datos_registro_crear():
+    datos = MagicMock()
+    datos.usuario = 1
+    datos.retorno = 1
+    datos.num_parqueadero_carro = 0
+    datos.num_parqueadero_moto = 0
+    return datos
 
-@pytest.mark.asyncio
-async def test_crear_registro_retorno_exitoso(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock, usuario_mock, registro_retorno_mock):
-    data = MagicMock()
-    data.usuario = 1
-    data.retorno = 1
+@pytest.fixture
+def datos_registro_editar():
+    datos = MagicMock()
+    datos.num_transporte = 2
+    datos.num_hospedaje = 2
+    datos.num_parqueadero_carro = 0
+    datos.num_parqueadero_moto = 1
+    datos.anotaciones = "Actualizando registro"
+    return datos
 
+@pytest.fixture
+def datos_darse_de_baja():
+    datos = MagicMock()
+    datos.usuario = 1
+    datos.retorno = 1
+    return datos
+
+def setup_crear_registro_mocks(mock_retorno_repositorio, mock_usuario_servicio, 
+                               mock_repositorio, retorno_mock, usuario_mock, 
+                               ya_registrado=False):
+    """Helper para configurar mocks comunes en crear_registro_retorno."""
     mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
     mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
-    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.return_value = None
+    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.return_value = (
+        MagicMock() if ya_registrado else None
+    )
+
+def create_estado_mock(valor="activo"):
+    """Helper para crear un mock de Enum estado."""
+    estado = MagicMock()
+    estado.value = valor
+    estado.__eq__ = lambda self, other: other == valor
+    estado.__ne__ = lambda self, other: other != valor
+    return estado
+
+@pytest.mark.asyncio
+async def test_crear_registro_retorno_exitoso(
+    servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio,
+    retorno_mock, usuario_mock, registro_retorno_mock, datos_registro_crear
+):
+    """Caso de éxito: El registro se crea correctamente."""
+    setup_crear_registro_mocks(mock_retorno_repositorio, mock_usuario_servicio,
+                               mock_repositorio, retorno_mock, usuario_mock)
     mock_repositorio.crear_registro_retorno.return_value = registro_retorno_mock
 
-    resultado = await servicio.crear_registro_retorno(data)
-
-    mock_retorno_repositorio.get_by_codigo.assert_called_once_with(1)
-    mock_usuario_servicio.obtener_usuario_por_id.assert_called_once_with(1)
-    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.assert_called_once_with(1, 1)
-    mock_repositorio.crear_registro_retorno.assert_called_once_with(data)
-    assert resultado == registro_retorno_mock
+    with patch('app.retornos.servicios.registro_retorno_servicio.RegistroRetornoRespuesta') as mock_schema:
+        mock_schema.model_validate.return_value = MagicMock(reg_codigo=1)
+        resultado = await servicio.crear_registro_retorno(datos_registro_crear)
+        
+        assert resultado.reg_codigo == 1
+        mock_repositorio.crear_registro_retorno.assert_called_once_with(datos_registro_crear)
 
 @pytest.mark.asyncio
-async def test_crear_registro_retorno_retorno_no_existente(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio):
-    data = MagicMock()
-    data.usuario = 1
-    data.retorno = 1
-
+async def test_crear_registro_retorno_no_existente(servicio, mock_retorno_repositorio, datos_registro_crear):
+    """Error: El retorno especificado no existe (404)."""
     mock_retorno_repositorio.get_by_codigo.return_value = None
 
-    with pytest.raises(RetornoNoExistente) as exc_info:
-        await servicio.crear_registro_retorno(data)
-
-    assert exc_info.value.detail == "El retorno con código 1 no existe."
+    with pytest.raises(RetornoNoExistente):
+        await servicio.crear_registro_retorno(datos_registro_crear)
 
 @pytest.mark.asyncio
-async def test_crear_registro_retorno_retorno_finalizado(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock):
-    data = MagicMock()
-    data.usuario = 1
-    data.retorno = 1
-
-    retorno_mock.estado = "finalizado"
+async def test_crear_registro_retorno_finalizado(
+    servicio, mock_retorno_repositorio, retorno_mock, datos_registro_crear
+):
+    """Error: El retorno ya ha finalizado (400)."""
+    retorno_mock.estado = create_estado_mock("finalizado")
     mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
 
-    with pytest.raises(RetornoEstadoFinalizado) as exc_info:
-        await servicio.crear_registro_retorno(data)
-
-    assert exc_info.value.detail == "No es posible inscribir en el retorno con código 1 porque ya ha finalizado."
+    with pytest.raises(RetornoEstadoInvalido):
+        await servicio.crear_registro_retorno(datos_registro_crear)
 
 @pytest.mark.asyncio
-async def test_crear_registro_retorno_usuario_no_existente(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock):
-    data = MagicMock()
-    data.usuario = 1
-    data.retorno = 1
-
+async def test_crear_registro_usuario_no_existente(
+    servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio,
+    retorno_mock, datos_registro_crear
+):
+    """Error: El usuario especificado no existe (404)."""
     mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
     mock_usuario_servicio.obtener_usuario_por_id.return_value = None
 
-    with pytest.raises(UsuarioNoExistente) as exc_info:
-        await servicio.crear_registro_retorno(data)
-
-    assert exc_info.value.detail == "El usuario con código 1 no existe."
+    with pytest.raises(UsuarioNoExistente):
+        await servicio.crear_registro_retorno(datos_registro_crear)
 
 @pytest.mark.asyncio
-async def test_crear_registro_retorno_usuario_sin_colonia(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock):
-    data = MagicMock()
-    data.usuario = 1
-    data.retorno = 1
-
-    usuario_mock = MagicMock()
-    usuario_mock.co_codigo = None
-
+async def test_crear_registro_usuario_sin_colonia(
+    servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio,
+    retorno_mock, datos_registro_crear
+):
+    """Error: El usuario no pertenece a ninguna colonia (400)."""
+    usuario_sin_colonia = MagicMock()
+    usuario_sin_colonia.us_codigo = 1
+    usuario_sin_colonia.co_codigo = None
+    
     mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
-    mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_sin_colonia
 
-    with pytest.raises(UsuarioSinColonia) as exc_info:
-        await servicio.crear_registro_retorno(data)
-
-    assert exc_info.value.detail == "El usuario con código 1 no pertenece a ninguna colonia."
+    with pytest.raises(UsuarioSinColonia):
+        await servicio.crear_registro_retorno(datos_registro_crear)
 
 @pytest.mark.asyncio
-async def test_crear_registro_retorno_usuario_ya_registrado(servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio, retorno_mock, usuario_mock):
-    data = MagicMock()
-    data.usuario = 1
-    data.retorno = 1
+async def test_crear_registro_usuario_ya_registrado(
+    servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio,
+    retorno_mock, usuario_mock, datos_registro_crear
+):
+    """Error: El usuario ya está registrado en ese retorno (409)."""
+    setup_crear_registro_mocks(mock_retorno_repositorio, mock_usuario_servicio,
+                               mock_repositorio, retorno_mock, usuario_mock,
+                               ya_registrado=True)
 
+    with pytest.raises(UsuarioYaRegistrado):
+        await servicio.crear_registro_retorno(datos_registro_crear)
+
+@pytest.mark.asyncio
+async def test_crear_registro_parqueaderos_excedidos(
+    servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio,
+    retorno_mock, usuario_mock, datos_registro_crear
+):
+    """Error: Se solicita más de 1 parqueadero para un registro individual (400)."""
+    setup_crear_registro_mocks(mock_retorno_repositorio, mock_usuario_servicio,
+                               mock_repositorio, retorno_mock, usuario_mock)
+    
+    datos_registro_crear.num_parqueadero_carro = 1
+    datos_registro_crear.num_parqueadero_moto = 1
+
+    with pytest.raises(RegistroIndividualParqueaderoExcedidoError):
+        await servicio.crear_registro_retorno(datos_registro_crear)
+
+@pytest.mark.asyncio
+async def test_editar_registro_retorno_exitoso(
+    servicio, mock_repositorio, mock_retorno_repositorio,
+    registro_retorno_mock, retorno_mock, datos_registro_editar
+):
+    """Caso de éxito: El registro se edita correctamente."""
+    mock_repositorio.obtener_registro_retorno_por_id.return_value = registro_retorno_mock
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+    mock_repositorio.actualizar_registro_retorno.return_value = None
+
+    with patch('app.retornos.servicios.registro_retorno_servicio.RegistroRetornoRespuesta') as mock_schema:
+        mock_schema.model_validate.return_value = MagicMock(reg_codigo=1)
+        resultado = await servicio.editar_registro_retorno(1, datos_registro_editar)
+        
+        assert resultado.reg_codigo == 1
+        mock_repositorio.actualizar_registro_retorno.assert_called_once_with(1, datos_registro_editar)
+
+@pytest.mark.asyncio
+async def test_editar_registro_no_existente(
+    servicio, mock_repositorio, datos_registro_editar
+):
+    """Error: El registro a editar no existe (404)."""
+    mock_repositorio.obtener_registro_retorno_por_id.return_value = None
+
+    with pytest.raises(RegistroRetornoNoExistente):
+        await servicio.editar_registro_retorno(999, datos_registro_editar)
+
+@pytest.mark.asyncio
+async def test_editar_registro_retorno_finalizado(
+    servicio, mock_repositorio, mock_retorno_repositorio,
+    registro_retorno_mock, retorno_mock, datos_registro_editar
+):
+    """Error: No se puede editar un registro de un retorno finalizado (400)."""
+    retorno_mock.estado = create_estado_mock("finalizado")
+    
+    mock_repositorio.obtener_registro_retorno_por_id.return_value = registro_retorno_mock
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+
+    with pytest.raises(RetornoEstadoInvalido):
+        await servicio.editar_registro_retorno(1, datos_registro_editar)
+
+@pytest.mark.asyncio
+async def test_obtener_registro_existente(
+    servicio, mock_repositorio, registro_retorno_mock
+):
+    """Caso de éxito: Se obtiene un registro existente."""
+    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.return_value = registro_retorno_mock
+
+    with patch('app.retornos.servicios.registro_retorno_servicio.RegistroRetornoRespuesta') as mock_schema:
+        mock_schema.model_validate.return_value = MagicMock(reg_codigo=1)
+        resultado = await servicio.obtener_registro_retorno_por_usuario_y_retorno(1, 1)
+        
+        assert resultado.reg_codigo == 1
+        mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.assert_called_once_with(1, 1)
+
+@pytest.mark.asyncio
+async def test_obtener_registro_no_existente(servicio, mock_repositorio):
+    """Caso: El registro no existe, retorna None."""
+    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.return_value = None
+
+    resultado = await servicio.obtener_registro_retorno_por_usuario_y_retorno(1, 1)
+    
+    assert resultado is None
+
+# ===== PRUEBAS: darse_de_baja =====
+
+@pytest.mark.asyncio
+async def test_darse_de_baja_exitoso(
+    servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio,
+    retorno_mock, usuario_mock, datos_darse_de_baja
+):
+    """Caso de éxito: El usuario se da de baja exitosamente."""
     mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
     mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
     mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.return_value = MagicMock()
+    mock_repositorio.eliminar_registro_retorno.return_value = True
 
-    with pytest.raises(UsuarioYaRegistrado) as exc_info:
-        await servicio.crear_registro_retorno(data)
+    resultado = await servicio.darse_de_baja(datos_darse_de_baja)
+    
+    assert resultado is True
+    mock_repositorio.eliminar_registro_retorno.assert_called_once_with(datos_darse_de_baja)
 
-    assert exc_info.value.detail == "El usuario con código 1 ya está registrado en el retorno con código 1."
+@pytest.mark.asyncio
+async def test_darse_de_baja_retorno_no_existente(
+    servicio, mock_retorno_repositorio, datos_darse_de_baja
+):
+    """Error: El retorno no existe (404)."""
+    mock_retorno_repositorio.get_by_codigo.return_value = None
+
+    with pytest.raises(RetornoNoExistente):
+        await servicio.darse_de_baja(datos_darse_de_baja)
+
+@pytest.mark.asyncio
+async def test_darse_de_baja_usuario_no_existente(
+    servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio,
+    retorno_mock, datos_darse_de_baja
+):
+    """Error: El usuario no existe (404)."""
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = None
+
+    with pytest.raises(UsuarioNoExistente):
+        await servicio.darse_de_baja(datos_darse_de_baja)
+
+@pytest.mark.asyncio
+async def test_darse_de_baja_usuario_no_registrado(
+    servicio, mock_repositorio, mock_retorno_repositorio, mock_usuario_servicio,
+    retorno_mock, usuario_mock, datos_darse_de_baja
+):
+    """Error: El usuario no está registrado en ese retorno (404)."""
+    mock_retorno_repositorio.get_by_codigo.return_value = retorno_mock
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
+    mock_repositorio.obtener_registro_retorno_por_usuario_y_retorno.return_value = None
+
+    with pytest.raises(UsuarioNoRegistradoEnRetorno):
+        await servicio.darse_de_baja(datos_darse_de_baja)
+
+@pytest.mark.asyncio
+async def test_obtener_registros_retorno_por_usuario(servicio, mock_repositorio):
+    """Caso de éxito: Se obtienen los registros del usuario."""
+    registros_mock = [MagicMock(), MagicMock()]
+    mock_repositorio.obtener_registros_retorno_por_usuario.return_value = registros_mock
+
+    resultado = await servicio.obtener_registros_retorno_por_usuario(1)
+    
+    assert len(resultado) == 2
+    mock_repositorio.obtener_registros_retorno_por_usuario.assert_called_once_with(1)
+
+@pytest.mark.asyncio
+async def test_obtener_registros_retorno_activos_exitoso(
+    servicio, mock_repositorio, mock_usuario_servicio, usuario_mock
+):
+    """Caso de éxito: Se obtienen los registros activos del usuario."""
+    registros_activos = [MagicMock(), MagicMock()]
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = usuario_mock
+    mock_repositorio.obtener_registros_retorno_activos_usuario.return_value = registros_activos
+
+    resultado = await servicio.obtener_registros_retorno_activos_por_usuario(1)
+    
+    assert len(resultado) == 2
+    mock_repositorio.obtener_registros_retorno_activos_usuario.assert_called_once_with(1)
+
+@pytest.mark.asyncio
+async def test_obtener_registros_retorno_activos_usuario_no_existente(
+    servicio, mock_usuario_servicio
+):
+    """Error: El usuario no existe (404)."""
+    mock_usuario_servicio.obtener_usuario_por_id.return_value = None
+
+    with pytest.raises(UsuarioNoExistente):
+        await servicio.obtener_registros_retorno_activos_por_usuario(999)


### PR DESCRIPTION
## Descripción del Cambio
Se implementa la funcionalidad para obtener el registro de retorno asociado a un usuario dentro de un retorno específico.

### Cambios realizados
- Se agrega endpoint para obtener los registros de un usuario.
- Se implementa filtrado por retorno específico.
- Se documenta el endpoint en Swagger.

## ID de la Historia de Usuario
- **HU:**

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [x] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%?
- [x] ¿Las validaciones de negocio (Documento > 0, Celular 10 dígitos, etc.) están implementadas?

## ¿Cómo probar este cambio?

### Backend:
1. Levantar el proyecto con Docker.
2. Ingresar a Swagger (`/docs`).
3. Probar el endpoint de consulta de registros del grupo de retorno.
4. Ejemplo de parámetros:
-- Usuario: 1
-- Retorno: 1