### PR TITLE
Copia Feat[2GR-4]:expirar invitaciones registro grupo retorno 

### DIFF
--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -47,6 +47,7 @@ def obtener_registro_retorno_servicio(db: Annotated[AsyncSession, Depends(get_db
     repositorio = RegistroRetornoRepositorio(db)
     retorno_repositorio = RetornoRepository(db)
     
+    
     usuario_servicio = UsuarioServicio(UsuarioRepositorio(db), ParentescoRepositorio(db))
     
     return RegistroRetornoServicio(
@@ -61,8 +62,9 @@ def obtener_registro_retorno_grupo_servicio(db: Annotated[AsyncSession, Depends(
     repositorio_retorno = RetornoRepository(db)
     repositorio_usuario_grupo = RetornoGrupoUsuarioRepositorio(db)
     repositorio_persona = PersonaRepositorio(db) # Instanciar PersonaRepositorio
+    solicitudes_repositorio = SolicitudGrupoRetornoRepositorio(db) # Instanciar el repositorio de solicitudes
     return RegistroRetornoGrupoServicio(
-        repositorio_registro_grupo, repositorio_grupo, repositorio_retorno, repositorio_usuario_grupo, repositorio_persona
+        repositorio_registro_grupo, repositorio_grupo, repositorio_retorno, repositorio_usuario_grupo, repositorio_persona, solicitudes_repositorio
     )
 
 def obtener_grupo_retorno_servicio(db: Annotated[AsyncSession, Depends(get_db)]):

--- a/app/retornos/repositorios/solicitud_grupo_retorno_repositorio.py
+++ b/app/retornos/repositorios/solicitud_grupo_retorno_repositorio.py
@@ -106,5 +106,18 @@ class SolicitudGrupoRetornoRepositorio:
             )
             return result.scalars().all()
         
+        async def expirar_solicitudes_pendientes_por_grupo_retorno(self, grupo_retorno_id: int):
+            stmt = (
+                update(SolicitudGrupoRetorno)
+                .where(
+                    SolicitudGrupoRetorno.gr_codigo == grupo_retorno_id,
+                    SolicitudGrupoRetorno.solgr_estado == SolicitudGrupoRetornoEstado.PENDIENTE
+                )
+                .values(solgr_estado=SolicitudGrupoRetornoEstado.EXPIRADO)
+            )
+
+            await self.db.execute(stmt)
+            await self.db.commit()
+        
         
         

--- a/app/retornos/servicios/registro_retorno_grupo_servicio.py
+++ b/app/retornos/servicios/registro_retorno_grupo_servicio.py
@@ -9,6 +9,7 @@ from app.retornos.repositorios.registro_retorno_grupo_repositorio import Registr
 from app.retornos.repositorios.retorno_repositorio import RetornoRepository
 from app.retornos.repositorios.persona_repositorio import PersonaRepositorio
 from app.retornos.repositorios.retorno_grupo_usuario_repositorio import RetornoGrupoUsuarioRepositorio
+from app.retornos.repositorios.solicitud_grupo_retorno_repositorio import SolicitudGrupoRetornoRepositorio
 from app.usuarios.schemas.usuario_esquemas import UsuarioSalida
 from app.retornos.excepciones.registro_retorno_grupo_excepciones import (
     RetornoNoExistente, 
@@ -25,13 +26,15 @@ class RegistroRetornoGrupoServicio:
         repositorio_grupo: GrupoRetornoRepositorio,
         repositorio_retorno: RetornoRepository,
         repositorio_usuario_grupo: RetornoGrupoUsuarioRepositorio,
-        repositorio_persona: PersonaRepositorio # Nuevo repositorio para personas
+        repositorio_persona: PersonaRepositorio, # Nuevo repositorio para personas
+        repositorio_solicitudes: SolicitudGrupoRetornoRepositorio = None
     ):
         self.repositorio_registro_grupo = repositorio_registro_grupo
         self.repositorio_grupo = repositorio_grupo
         self.repositorio_retorno = repositorio_retorno
         self.repositorio_usuario_grupo = repositorio_usuario_grupo
         self.repositorio_persona = repositorio_persona # Asignar el nuevo repositorio
+        self.repositorio_solicitudes = repositorio_solicitudes
 
     def _validar_retorno(self, retorno, codigo_retorno, accion):
         if not retorno:
@@ -40,6 +43,13 @@ class RegistroRetornoGrupoServicio:
         if retorno.estado != "activo":
             raise RetornoNoActivo(codigo_retorno, retorno.estado.value, accion)
 
+    async def _expirar_solicitudes_pendientes(self, cod_grupo: int):
+        """Marca como expiradas todas las solicitudes pendientes para un grupo y retorno específicos."""
+        if not self.repositorio_solicitudes:
+            raise RuntimeError("El repositorio de solicitudes no está disponible para expirar solicitudes pendientes. Asegúrate de inyectar el repositorio de solicitudes al crear el servicio.")
+        
+        await self.repositorio_solicitudes.expirar_solicitudes_pendientes_por_grupo_retorno(cod_grupo)
+           
     async def crear_registro_retorno_grupo(self, datos: RegistroRetornoGrupoCrear) -> RegistroRetornoGrupoRespuesta:
         """
         Registra un grupo en un retorno aplicando validaciones de negocio.
@@ -103,6 +113,9 @@ class RegistroRetornoGrupoServicio:
         registro = await self.repositorio_registro_grupo.crear_registro_grupo_retorno(datos)
         #asociar al lider con el grupo de retorno registrado
         await self.repositorio_usuario_grupo.asociar_usuario_a_grupo_retorno(grupo.us_codigo_lider, datos.cod_grupo)
+
+        # Expirar solicitudes pendientes para este grupo y retorno
+        await self._expirar_solicitudes_pendientes(datos.cod_grupo)
         return RegistroRetornoGrupoRespuesta.model_validate(registro)
 
     async def obtener_miembros_por_grupo(self, gr_codigo: int) -> list[UsuarioSalida]:

--- a/tests/retornos/test_registro_retorno_grupo_servicio.py
+++ b/tests/retornos/test_registro_retorno_grupo_servicio.py
@@ -13,7 +13,8 @@ def mocks():
         "repo_grupo": MagicMock(),
         "repo_retorno": MagicMock(),
         "repo_usuario_grupo": MagicMock(),
-        "repo_persona": MagicMock()
+        "repo_persona": MagicMock(),
+        "repo_solicitudes": MagicMock()
     }
 
 @pytest.fixture
@@ -24,7 +25,8 @@ def servicio(mocks):
         mocks["repo_grupo"],
         mocks["repo_retorno"],
         mocks["repo_usuario_grupo"],
-        mocks["repo_persona"]
+        mocks["repo_persona"],
+        mocks["repo_solicitudes"]
     )
 
 @pytest.fixture
@@ -61,6 +63,7 @@ def setup_crear_registro_mocks(mocks, grupo_lider=1, retorno_codigo=1, retorno_e
     
     mock_entidad = MagicMock()
     mocks["repo_reg"].crear_registro_grupo_retorno = AsyncMock(return_value=mock_entidad)
+    mocks["repo_solicitudes"].expirar_solicitudes_pendientes_por_grupo_retorno = AsyncMock()
 
 def setup_consultar_registro_mocks(mocks, retorno_existe=True, grupo_existe=True, registro_existe=True):
     """Helper para configurar mocks comunes en pruebas de consultar_registro_por_grupo_y_retorno."""
@@ -96,6 +99,7 @@ async def test_crear_registro_grupo_exito(servicio, mocks, datos_crear):
         
         assert resultado.regg_codigo == 100
         mocks["repo_reg"].crear_registro_grupo_retorno.assert_called_once_with(datos_crear)
+        mocks["repo_solicitudes"].expirar_solicitudes_pendientes_por_grupo_retorno.assert_called_once_with(datos_crear.cod_grupo)
 
 @pytest.mark.asyncio
 async def test_crear_registro_grupo_no_existe(servicio, mocks, datos_crear):


### PR DESCRIPTION
## Descripción del Cambio
Copia de la PR #62 pero esta vez dirigida a dev. 

Esta PR contiene implementa la validación que se encarga de expirar las solicitudes de un grupo de retornos pendientes cuando se registran las necesidades del grupo a un retorno, esto con el propósito de que los usuarios no puedan interactuar con solicitudes después que el grupo haya sido registrado en un retorno. Además, también se actualizaron las pruebas de test_registro_grupo_retorno_servicio.py añadiendo el repositorio de solicitudes, especialmente, se actualizó la prueba test_crear_registro_grupo_exito para validar que  expirar_solicitudes_pendientes_por_grupo_retorno haya sido llamado. 

## ID de la Historia de Usuario
- No tiene código de HU asignado 

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [x] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%?
- [x] ¿Las validaciones de negocio (Documento > 0, Celular 10 dígitos, etc.) están implementadas?

## ¿Cómo probar este cambio?
**Backend:**
1. Levantar con Docker.
2. Probar en Swagger (`/docs`):
Propongo los siguientes pasos para probar la funcionalidad. 
- paso 1: crear 2 usuarios 
- paso 2: crear un grupo de retorno con uno de los usuarios anteriores como líder 
- paso 3: mandar una solicitud al grupo de retorno al otro usuario 
- paso 4: crear una persona 
- paso 5: asociar a la persona anterior a un grupo de retorno 
- paso 6: registrar las necesidades del grupo de retorno 
- paso 7: consultar las solicitudes del grupo de retorno, el resultado debe ser que la solicitud enviada al usuario debe estar expirada. 
