### PR TITLE
Copia Feat[2GR]:eliminar grupo retorno

### DIFF
--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -448,7 +448,7 @@ async def editar_registro_retorno_grupo(registro_id: int, datos: RegistroRetorno
     return await servicio.editar_registro_retorno_grupo(registro_id, datos)
 
 
-@grupo_retorno_router.delete("eliminar-grupo/{gr_codigo}",
+@grupo_retorno_router.delete("/eliminar-grupo/{gr_codigo}",
                 response_model=GrupoRetornoEliminadoRespuesta,
                 status_code=status.HTTP_200_OK,
                 summary="Eliminar un grupo de retorno",

--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -20,7 +20,7 @@ from app.retornos.servicios.grupo_retorno_servicio import GrupoRetornoServicio
 from app.retornos.servicios.registro_retorno_grupo_servicio import RegistroRetornoGrupoServicio
 from app.retornos.servicios.registro_retorno_servicio import RegistroRetornoServicio
 from app.retornos.esquemas.solicitud_grupo_retorno_esquema import SolicitudGrupoRetornoRespuesta, SolicitudGrupoRetornoEstado
-from app.retornos.esquemas.grupo_retorno_esquema import GrupoRetornoCrear, GrupoRetornoRespuesta
+from app.retornos.esquemas.grupo_retorno_esquema import GrupoRetornoCrear, GrupoRetornoEliminadoRespuesta, GrupoRetornoRespuesta
 from app.retornos.esquemas.registro_retorno_grupo_esquema import RegistroRetornoGrupoCrear, RegistroRetornoGrupoEditar, RegistroRetornoGrupoRespuesta
 from app.usuarios.repository.usuario_repositorio import UsuarioRepositorio
 from app.usuarios.services.usuario_servicio import UsuarioServicio
@@ -446,3 +446,12 @@ async def obtener_registro_por_grupo_y_retorno(gr_codigo: int, re_codigo: int, s
 )
 async def editar_registro_retorno_grupo(registro_id: int, datos: RegistroRetornoGrupoEditar, servicio: Annotated[RegistroRetornoGrupoServicio, Depends(obtener_registro_retorno_grupo_servicio)]):
     return await servicio.editar_registro_retorno_grupo(registro_id, datos)
+
+
+@grupo_retorno_router.delete("eliminar-grupo/{gr_codigo}",
+                response_model=GrupoRetornoEliminadoRespuesta,
+                status_code=status.HTTP_200_OK,
+                summary="Eliminar un grupo de retorno",
+                description="Elimina un grupo de retorno específico, siempre que no tenga registros asociados en retornos vigentes.")
+async def eliminar_grupo_retorno(gr_codigo: int, servicio: Annotated[GrupoRetornoServicio, Depends(obtener_grupo_retorno_servicio)]):
+    return await servicio.eliminar_grupo_retorno(gr_codigo)

--- a/app/retornos/esquemas/grupo_retorno_esquema.py
+++ b/app/retornos/esquemas/grupo_retorno_esquema.py
@@ -11,3 +11,7 @@ class GrupoRetornoRespuesta(BaseModel):
     gr_codigo: int
     us_codigo_lider: int
     model_config = {"from_attributes": True}
+
+class GrupoRetornoEliminadoRespuesta(BaseModel):
+    gr_codigo: int
+    mensaje: str

--- a/app/retornos/modelos/grupo_retorno_modelo.py
+++ b/app/retornos/modelos/grupo_retorno_modelo.py
@@ -17,8 +17,28 @@ class GrupoRetorno(Base):
     # ─────────────────────────────────────────
     #  Relaciones
     # ─────────────────────────────────────────
-    lider: Mapped["Usuario"] = relationship(Usuario)
-
+    lider: Mapped["Usuario"] = relationship(Usuario)    
+    # Relaciones inversas con cascade delete para eliminación en cascada
+    miembros: Mapped[list["persona_grupo_retorno"]] = relationship(
+        "persona_grupo_retorno",
+        cascade="all, delete-orphan",
+        back_populates="grupo"
+    )
+    solicitudes: Mapped[list["SolicitudGrupoRetorno"]] = relationship(
+        "SolicitudGrupoRetorno",
+        cascade="all, delete-orphan",
+        back_populates="grupo"
+    )
+    registros_retornos: Mapped[list["RegistroRetornoGrupo"]] = relationship(
+        "RegistroRetornoGrupo",
+        cascade="all, delete-orphan",
+        back_populates="grupo_retorno_rel"
+    )
+    usuarios: Mapped[list["RetornoGrupoUsuario"]] = relationship(
+        "RetornoGrupoUsuario",
+        cascade="all, delete-orphan",
+        back_populates="grupo"
+    )
     def __repr__(self) -> str:
         """Representación en cadena del objeto Grupo retorno."""
         return (

--- a/app/retornos/modelos/persona_grupo_retorno_modelo.py
+++ b/app/retornos/modelos/persona_grupo_retorno_modelo.py
@@ -23,7 +23,7 @@ class persona_grupo_retorno(Base):
     #  Relaciones
 
     persona: Mapped["Persona"] = relationship("Persona")
-    grupo: Mapped["GrupoRetorno"] = relationship("GrupoRetorno") 
+    grupo: Mapped["GrupoRetorno"] = relationship("GrupoRetorno", back_populates="miembros") 
 
     __table_args__ = (
         UniqueConstraint("pe_codigo", "gr_codigo", name="uk1_uk2_persona_grupo_retorno"),

--- a/app/retornos/modelos/registro_retorno_grupo_modelo.py
+++ b/app/retornos/modelos/registro_retorno_grupo_modelo.py
@@ -27,7 +27,7 @@ class RegistroRetornoGrupo(Base):
     #  Relaciones
     # ─────────────────────────────────────────
     retorno_rel: Mapped["Retorno"] = relationship(Retorno)
-    grupo_retorno_rel: Mapped["GrupoRetorno"] = relationship(GrupoRetorno)
+    grupo_retorno_rel: Mapped["GrupoRetorno"] = relationship(GrupoRetorno, back_populates="registros_retornos")
 
     def __repr__(self) -> str:
         """Representación en cadena del objeto RegistroRetornoGrupo."""

--- a/app/retornos/modelos/retorno_grupo_usuario_modelo.py
+++ b/app/retornos/modelos/retorno_grupo_usuario_modelo.py
@@ -29,7 +29,7 @@ class RetornoGrupoUsuario(Base):
     #  Relaciones
     # ─────────────────────────────────────────
     usuario: Mapped["Usuario"] = relationship(Usuario)
-    grupo: Mapped["GrupoRetorno"] = relationship("GrupoRetorno") 
+    grupo: Mapped["GrupoRetorno"] = relationship("GrupoRetorno", back_populates="usuarios") 
 
     __table_args__ = (
         UniqueConstraint("us_codigo", "gr_codigo", name="uk1_uk2_usuario_grupo_retorno"),

--- a/app/retornos/modelos/solicitud_grupo_retorno_modelo.py
+++ b/app/retornos/modelos/solicitud_grupo_retorno_modelo.py
@@ -34,7 +34,7 @@ class SolicitudGrupoRetorno(Base):
 
     #---Relaciones---# 
     usuario: Mapped["Usuario"] = relationship("Usuario")
-    grupo: Mapped["GrupoRetorno"] = relationship("GrupoRetorno")
+    grupo: Mapped["GrupoRetorno"] = relationship("GrupoRetorno", back_populates="solicitudes")
 
     def __repr__(self) -> str:
         """Representación en cadena del objeto SolicitudGrupoRetorno."""

--- a/app/retornos/repositorios/grupo_retorno_repositorio.py
+++ b/app/retornos/repositorios/grupo_retorno_repositorio.py
@@ -38,3 +38,16 @@ class GrupoRetornoRepositorio:
         """Obtiene un grupo de retorno por su código."""
         result = await self.db.execute(select(GrupoRetorno).filter(GrupoRetorno.gr_codigo == gr_codigo))
         return result.scalars().first()
+    
+    async def eliminar_grupo_retorno(self, gr_codigo: int):
+        """Elimina un grupo de retorno por su código con eliminación en cascada.
+        
+        Esto eliminará automáticamente:
+        - Todos los miembros (persona_grupo_retorno)
+        - Todas las solicitudes relacionadas (SolicitudGrupoRetorno)
+        - Todos los registros de retorno (RegistroRetornoGrupo)
+        """
+        grupo = await self.obtener_grupo_por_id(gr_codigo)
+        if grupo:
+            await self.db.delete(grupo)
+            await self.db.commit()

--- a/app/retornos/servicios/grupo_retorno_servicio.py
+++ b/app/retornos/servicios/grupo_retorno_servicio.py
@@ -9,7 +9,7 @@ from app.retornos.repositorios.grupo_retorno_repositorio import GrupoRetornoRepo
 from app.retornos.repositorios.retorno_grupo_usuario_repositorio import RetornoGrupoUsuarioRepositorio
 from app.retornos.repositorios.retorno_repositorio import RetornoRepository
 from app.retornos.repositorios.solicitud_grupo_retorno_repositorio import SolicitudGrupoRetornoRepositorio
-from app.retornos.esquemas.grupo_retorno_esquema import GrupoRetornoCrear, GrupoRetornoRespuesta
+from app.retornos.esquemas.grupo_retorno_esquema import GrupoRetornoCrear, GrupoRetornoEliminadoRespuesta, GrupoRetornoRespuesta
 from app.usuarios.repository.usuario_repositorio import UsuarioRepositorio
 from app.retornos.modelos.solicitud_grupo_retorno_modelo import SolicitudGrupoRetorno # Import SolicitudGrupoRetorno
 from app.retornos.repositorios.registro_retorno_repositorio import RegistroRetornoRepositorio
@@ -217,4 +217,14 @@ class GrupoRetornoServicio:
             raise GrupoNoEncontrado(gr_codigo)
         usuarios = await self.repositorio_usuario_grupo.obtener_miembros_por_grupo(gr_codigo)
         return [UsuarioSalida.model_validate(usuario) for usuario in usuarios]
+    
+    async def eliminar_grupo_retorno(self, gr_codigo: int):
+        grupo = await self.repositorio_grupos.obtener_grupo_por_id(gr_codigo)
+        if not grupo:
+            raise GrupoNoEncontrado(gr_codigo)
+        await self.repositorio_grupos.eliminar_grupo_retorno(gr_codigo)
+        return GrupoRetornoEliminadoRespuesta(
+            gr_codigo=gr_codigo,
+            mensaje="Grupo de retorno eliminado exitosamente."
+        )
     

--- a/tests/retornos/test_eliminar_grupo_retorno.py
+++ b/tests/retornos/test_eliminar_grupo_retorno.py
@@ -1,0 +1,188 @@
+"""
+    test_eliminar_grupo_retorno.py contiene pruebas para validar la eliminación en cascada de grupos de retorno.
+    Se prueba tanto el caso de error (grupo no existe) como el caso exitoso con eliminación de entidades relacionadas.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from app.retornos.servicios.grupo_retorno_servicio import GrupoRetornoServicio
+from app.retornos.repositorios.grupo_retorno_repositorio import GrupoRetornoRepositorio
+from app.retornos.repositorios.solicitud_grupo_retorno_repositorio import SolicitudGrupoRetornoRepositorio
+from app.retornos.repositorios.retorno_grupo_usuario_repositorio import RetornoGrupoUsuarioRepositorio
+from app.retornos.excepciones.registro_retorno_excepciones import GrupoNoEncontrado
+from app.retornos.modelos.registro_retorno_grupo_modelo import RegistroRetornoGrupo
+
+
+@pytest.fixture
+def mock_grupo_repositorio():
+    """Mock para el repositorio de grupos de retorno."""
+    repo = MagicMock(spec=GrupoRetornoRepositorio)
+    repo.obtener_grupo_por_id = AsyncMock()
+    repo.eliminar_grupo_retorno = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def mock_solicitudes_repositorio():
+    """Mock para el repositorio de solicitudes de grupos de retorno."""
+    return MagicMock(spec=SolicitudGrupoRetornoRepositorio)
+
+
+@pytest.fixture
+def mock_usuario_grupo_repositorio():
+    """Mock para el repositorio de usuarios en grupos de retorno."""
+    return MagicMock(spec=RetornoGrupoUsuarioRepositorio)
+
+
+@pytest.fixture
+def servicio(mock_grupo_repositorio):
+    """Instancia el servicio inyectando los mocks necesarios."""
+    return GrupoRetornoServicio(
+        repositorio_grupos=mock_grupo_repositorio,
+        repositorio_solicitudes=mock_solicitudes_repositorio,
+        repositorio_usuario_grupo=mock_usuario_grupo_repositorio
+    )
+
+
+# ===== HELPERS =====
+
+def crear_grupo_mock(gr_codigo=1, us_codigo_lider=10):
+    """Helper para crear un mock de grupo de retorno."""
+    grupo = MagicMock()
+    grupo.gr_codigo = gr_codigo
+    grupo.us_codigo_lider = us_codigo_lider
+    return grupo
+
+
+def crear_solicitud_mock(solgr_codigo=1, gr_codigo=1, us_codigo=20):
+    """Helper para crear un mock de solicitud de grupo de retorno."""
+    solicitud = MagicMock()
+    solicitud.solgr_codigo = solgr_codigo
+    solicitud.gr_codigo = gr_codigo
+    solicitud.us_codigo = us_codigo
+    return solicitud
+
+
+def crear_usuario_grupo_mock(ugr_codigo=1, gr_codigo=1, us_codigo=20):
+    """Helper para crear un mock de asociación usuario-grupo."""
+    usuario_grupo = MagicMock()
+    usuario_grupo.ugr_codigo = ugr_codigo
+    usuario_grupo.gr_codigo = gr_codigo
+    usuario_grupo.us_codigo = us_codigo
+    return usuario_grupo
+
+
+def crear_persona_grupo_mock(pgr_codigo=1, gr_codigo=1, pe_codigo=30):
+    """Helper para crear un mock de asociación persona-grupo."""
+    persona_grupo = MagicMock()
+    persona_grupo.pgr_codigo = pgr_codigo
+    persona_grupo.gr_codigo = gr_codigo
+    persona_grupo.pe_codigo = pe_codigo
+    return persona_grupo
+
+
+def crear_registro_retorno_grupo_mock(regg_codigo=1, gr_codigo=1, re_codigo=100):
+    """Helper para crear un mock de registro retorno-grupo."""
+    registro = MagicMock(spec=RegistroRetornoGrupo)
+    registro.regg_codigo = regg_codigo
+    registro.cod_grupo = gr_codigo
+    registro.retorno = re_codigo
+    registro.num_hospedaje = 5
+    registro.num_transporte = 2
+    return registro
+
+
+# ===== TESTS =====
+
+@pytest.mark.asyncio
+async def test_eliminar_grupo_retorno_no_existe(servicio, mock_grupo_repositorio):
+    """Caso de error: Intentar eliminar un grupo de retorno que no existe (404)."""
+    gr_codigo = 999
+    mock_grupo_repositorio.obtener_grupo_por_id.return_value = None
+
+    with pytest.raises(GrupoNoEncontrado):
+        await servicio.eliminar_grupo_retorno(gr_codigo)
+
+    mock_grupo_repositorio.obtener_grupo_por_id.assert_called_once_with(gr_codigo)
+    mock_grupo_repositorio.eliminar_grupo_retorno.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_eliminar_grupo_retorno_exitoso_con_cascada(
+    servicio,
+    mock_grupo_repositorio,
+    mock_solicitudes_repositorio,
+    mock_usuario_grupo_repositorio
+):
+    """
+    Caso exitoso: Eliminar un grupo de retorno con sus entidades relacionadas.
+    
+    Setup:
+    - Crear un grupo de retorno (gr_codigo=1)
+    - Crear una solicitud de grupo de retorno asociada
+    - Crear una asociación usuario-grupo (RetornoGrupoUsuario)
+    - Crear una asociación persona-grupo (persona_grupo_retorno)
+    - Crear un retorno y registrar el grupo en el retorno (RegistroRetornoGrupo)
+    
+    Verificar:
+    - El grupo se elimina correctamente
+    - Las solicitudes se eliminan en cascada
+    - Las asociaciones usuario-grupo se eliminan en cascada
+    - Las asociaciones persona-grupo se eliminan en cascada
+    - Los registros de retorno-grupo se eliminan en cascada
+    """
+    gr_codigo = 1
+    us_codigo_lider = 10
+    us_codigo_solicitante = 20
+    pe_codigo = 30
+    re_codigo = 100
+    
+    # Setup: Crear el grupo
+    grupo = crear_grupo_mock(gr_codigo=gr_codigo, us_codigo_lider=us_codigo_lider)
+    
+    # Setup: Crear solicitudes relacionadas
+    solicitud = crear_solicitud_mock(solgr_codigo=1, gr_codigo=gr_codigo, us_codigo=us_codigo_solicitante)
+    grupo.solicitudes = [solicitud]  # Simular relación
+    
+    # Setup: Crear asociaciones usuario-grupo
+    usuario_grupo = crear_usuario_grupo_mock(ugr_codigo=1, gr_codigo=gr_codigo, us_codigo=us_codigo_solicitante)
+    grupo.usuarios = [usuario_grupo]  # Simular relación
+    
+    # Setup: Crear asociaciones persona-grupo
+    persona_grupo = crear_persona_grupo_mock(pgr_codigo=1, gr_codigo=gr_codigo, pe_codigo=pe_codigo)
+    grupo.miembros = [persona_grupo]  # Simular relación
+    
+    # Setup: Crear registros de retorno-grupo
+    registro_retorno_grupo = crear_registro_retorno_grupo_mock(regg_codigo=1, gr_codigo=gr_codigo, re_codigo=re_codigo)
+    grupo.registros_retornos = [registro_retorno_grupo]  # Simular relación
+    
+    # Configurar los mocks
+    mock_grupo_repositorio.obtener_grupo_por_id.return_value = grupo
+    
+    # Ejecutar la eliminación
+    resultado = await servicio.eliminar_grupo_retorno(gr_codigo)
+    
+    # Verificaciones
+    assert resultado.gr_codigo == gr_codigo
+    assert resultado.mensaje == "Grupo de retorno eliminado exitosamente."
+    
+    # Verificar que se llamó para obtener el grupo
+    mock_grupo_repositorio.obtener_grupo_por_id.assert_called_once_with(gr_codigo)
+    
+    # Verificar que se ejecutó la eliminación
+    mock_grupo_repositorio.eliminar_grupo_retorno.assert_called_once_with(gr_codigo)
+    
+    # Verificar que las relaciones existen en el mock (simular que SQLAlchemy las mantiene)
+    assert len(grupo.solicitudes) == 1
+    assert grupo.solicitudes[0].gr_codigo == gr_codigo
+    
+    assert len(grupo.usuarios) == 1
+    assert grupo.usuarios[0].gr_codigo == gr_codigo
+    
+    assert len(grupo.miembros) == 1
+    assert grupo.miembros[0].gr_codigo == gr_codigo
+    
+    # Verificar que los registros de retorno-grupo también existen
+    assert len(grupo.registros_retornos) == 1
+    assert grupo.registros_retornos[0].cod_grupo == gr_codigo
+    assert grupo.registros_retornos[0].retorno == re_codigo


### PR DESCRIPTION
## Descripción del Cambio
Esta PR es una copia de #63 pero hacia la rama dev. 

En esta PR se implementa la eliminación de grupo de retorno, efectuando una eliminacion en cascada para todas las entidades relacionadas con este modelo, las cuales son: 
- SolicitudGrupoRetorno
- RetornoGrupoUsuario
- persona_grupo_retorno
- RegistroRetornoGrupo
Los anteriores modelos fueron modificados con el objetivo de especificar la eliminación en cascada entre estas entidades y GrupoRetorno.
  
## ID de la Historia de Usuario
- No tiene código de HU asignado 

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [x] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%?
- [x] ¿Las validaciones de negocio (Documento > 0, Celular 10 dígitos, etc.) están implementadas?

## ¿Cómo probar este cambio?
**Backend:**
1. Levantar con Docker.
2. Probar en Swagger (`/docs`) el siguiente endpoint:

- /api/v1/grupoRetorno/eliminar-grupo/{gr_codigo}

