### PR TITLE
Copia Feat(1GU-2): aceptar y rechazar parentesco

### DIFF
--- a/app/usuarios/api/v1/usuario_router.py
+++ b/app/usuarios/api/v1/usuario_router.py
@@ -11,11 +11,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.usuarios.repository.parentesco_repositorio import ParentescoRepositorio
 from app.usuarios.repository.usuario_repositorio import UsuarioRepositorio
-from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoLista, ParentescoRespuestaDetallada
+from app.usuarios.schemas.parentesco_esquemas import ParentescoRespuesta, ParentescoRespuestaDetallada
 from app.usuarios.services.usuario_servicio import UsuarioServicio
 from app.usuarios.docs.registro_doc import registrar_docs, registrar_body
 from app.usuarios.docs.solicitud_parentesco_doc import solicitar_parentesco_docs, solicitar_parentesco_body
-from app.usuarios.schemas.usuario_esquemas import UsuarioConsultaColonia, UsuarioCrear, UsuarioSalida, UsuarioNombre, UsuarioDetallado
+from app.usuarios.schemas.usuario_esquemas import UsuarioConsultaColonia, UsuarioSalida, UsuarioNombre, UsuarioDetallado
 from app.usuarios.docs.registro_doc import registrar_body, registrar_docs
 from app.usuarios.docs.listar_parentescos_doc import listar_parentescos_docs
 
@@ -63,8 +63,8 @@ async def solicitar_parentesco(
     servicio: Annotated[UsuarioServicio, Depends(get_usuario_servicio)],
 ):
     try:
-        await servicio.solicitar_parentesco(parentesco_crear)
-        return {"mensaje": "Solicitud de parentesco enviada exitosamente."}
+        solicitud = await servicio.solicitar_parentesco(parentesco_crear)
+        return solicitud
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -72,7 +72,7 @@ async def solicitar_parentesco(
         )
     
 @router.patch("/solicitud-parentesco/aceptar/{solicitud_id}",
-               response_model=ParentescoLista,
+               response_model=ParentescoRespuesta,
                status_code=status.HTTP_200_OK, 
                summary="Aceptar solicitud de parentesco") 
 async def aceptar_solicitud_parentesco(
@@ -89,7 +89,7 @@ async def aceptar_solicitud_parentesco(
         )  
 
 @router.patch("/solicitud-parentesco/rechazar/{solicitud_id}", 
-              response_model=ParentescoLista,
+              response_model=ParentescoRespuesta,
               status_code=status.HTTP_200_OK, 
               summary="Rechazar solicitud de parentesco")
 async def rechazar_solicitud_parentesco(

--- a/app/usuarios/api/v1/usuario_router.py
+++ b/app/usuarios/api/v1/usuario_router.py
@@ -70,6 +70,34 @@ async def solicitar_parentesco(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
+    
+@router.patch("/solicitud-parentesco/aceptar/{solicitud_id}", status_code=status.HTTP_200_OK, summary="Aceptar solicitud de parentesco") 
+async def aceptar_solicitud_parentesco(
+    solicitud_id: int,
+    servicio: Annotated[UsuarioServicio, Depends(get_usuario_servicio)],
+):
+    try:
+        solicitud = await servicio.aceptar_solicitud_parentesco(solicitud_id)
+        return solicitud
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )  
+
+@router.patch("/solicitud-parentesco/rechazar/{solicitud_id}", status_code=status.HTTP_200_OK, summary="Rechazar solicitud de parentesco")
+async def rechazar_solicitud_parentesco(
+    solicitud_id: int,
+    servicio: Annotated[UsuarioServicio, Depends(get_usuario_servicio)],
+):
+    try:
+        solicitud =  await servicio.rechazar_solicitud_parentesco(solicitud_id)
+        return solicitud
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )     
 
 @router.get("/", response_model=list[UsuarioSalida], summary="Listar todos los usuarios (básico)")
 async def listar_usuarios(

--- a/app/usuarios/api/v1/usuario_router.py
+++ b/app/usuarios/api/v1/usuario_router.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.usuarios.repository.parentesco_repositorio import ParentescoRepositorio
 from app.usuarios.repository.usuario_repositorio import UsuarioRepositorio
-from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoRespuestaDetallada
+from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoLista, ParentescoRespuestaDetallada
 from app.usuarios.services.usuario_servicio import UsuarioServicio
 from app.usuarios.docs.registro_doc import registrar_docs, registrar_body
 from app.usuarios.docs.solicitud_parentesco_doc import solicitar_parentesco_docs, solicitar_parentesco_body
@@ -71,7 +71,10 @@ async def solicitar_parentesco(
             detail=str(e),
         )
     
-@router.patch("/solicitud-parentesco/aceptar/{solicitud_id}", status_code=status.HTTP_200_OK, summary="Aceptar solicitud de parentesco") 
+@router.patch("/solicitud-parentesco/aceptar/{solicitud_id}",
+               response_model=ParentescoLista,
+               status_code=status.HTTP_200_OK, 
+               summary="Aceptar solicitud de parentesco") 
 async def aceptar_solicitud_parentesco(
     solicitud_id: int,
     servicio: Annotated[UsuarioServicio, Depends(get_usuario_servicio)],
@@ -85,7 +88,10 @@ async def aceptar_solicitud_parentesco(
             detail=str(e),
         )  
 
-@router.patch("/solicitud-parentesco/rechazar/{solicitud_id}", status_code=status.HTTP_200_OK, summary="Rechazar solicitud de parentesco")
+@router.patch("/solicitud-parentesco/rechazar/{solicitud_id}", 
+              response_model=ParentescoLista,
+              status_code=status.HTTP_200_OK, 
+              summary="Rechazar solicitud de parentesco")
 async def rechazar_solicitud_parentesco(
     solicitud_id: int,
     servicio: Annotated[UsuarioServicio, Depends(get_usuario_servicio)],
@@ -188,8 +194,7 @@ async def buscar_usuario_por_documento(
 @router.get(
     "/{codigo_usuario}/parentescos",
     status_code=status.HTTP_200_OK,
-    **listar_parentescos_docs
-)
+    **listar_parentescos_docs)
 async def listar_parentescos_usuario(
     codigo_usuario: int,
     servicio: Annotated[UsuarioServicio, Depends(get_usuario_servicio)],
@@ -203,6 +208,20 @@ async def listar_parentescos_usuario(
             detail=str(e),
         )
 
+@router.get("/parentesco/{parentesco_id}", response_model=ParentescoRespuestaDetallada, summary="Obtener detalles de un parentesco por ID")
+async def obtener_parentesco_por_id(
+    parentesco_id: int,
+    servicio: Annotated[UsuarioServicio, Depends(get_usuario_servicio)],
+):
+    try:
+        parentesco = await servicio.obtener_parentesco_por_id(parentesco_id)
+        return parentesco
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
+    
 @router.get("/colonia/{colonia}", response_model=list[UsuarioConsultaColonia], summary="Buscar usuarios por colonia")
 async def buscar_usuario_por_colonia(
     colonia: int, 

--- a/app/usuarios/docs/listar_parentescos_doc.py
+++ b/app/usuarios/docs/listar_parentescos_doc.py
@@ -5,7 +5,7 @@ las relaciones de parentesco asociadas a un usuario específico, ya sea como sol
 Se incluyen detalles sobre el acceso, los parámetros requeridos y las posibles respuestas del endpoint.
 """
 
-from app.usuarios.schemas.parentesco_esquemas import ParentescoLista, ParentescoRespuestaDetallada
+from app.usuarios.schemas.parentesco_esquemas import ParentescoRespuestaDetallada
 from fastapi import Body
 from typing import Annotated
 
@@ -27,17 +27,33 @@ las relaciones de parentesco asociadas a un usuario específico, ya sea como sol
                     "example": [
                         {
                             "codigo": 1,
-                            "codigo_solicitante": 1,
-                            "codigo_destinatario": 2,
                             "tipo_parentesco": "hermano (a)",
-                            "estado": "aceptada"
+                            "estado": "aceptada",
+                            "solicitante": {
+                                "codigo": 1,
+                                "nombre": "Juan",
+                                "apellido": "García"
+                            },
+                            "destinatario": {
+                                "codigo": 2,
+                                "nombre": "María",
+                                "apellido": "García"
+                            }
                         },
                         {
                             "codigo": 2,
-                            "codigo_solicitante": 3,
-                            "codigo_destinatario": 1,
                             "tipo_parentesco": "padre",
-                            "estado": "pendiente"
+                            "estado": "pendiente",
+                            "solicitante": {
+                                "codigo": 3,
+                                "nombre": "Carlos",
+                                "apellido": "López"
+                            },
+                            "destinatario": {
+                                "codigo": 1,
+                                "nombre": "Juan",
+                                "apellido": "García"
+                            }
                         }
                     ]
                 }

--- a/app/usuarios/docs/listar_parentescos_doc.py
+++ b/app/usuarios/docs/listar_parentescos_doc.py
@@ -5,13 +5,13 @@ las relaciones de parentesco asociadas a un usuario específico, ya sea como sol
 Se incluyen detalles sobre el acceso, los parámetros requeridos y las posibles respuestas del endpoint.
 """
 
-from app.usuarios.schemas.parentesco_esquemas import ParentescoLista
+from app.usuarios.schemas.parentesco_esquemas import ParentescoLista, ParentescoRespuestaDetallada
 from fastapi import Body
 from typing import Annotated
 
 listar_parentescos_docs = dict(
     summary="Listar parentescos de un usuario",
-    response_model=list[ParentescoLista],
+    response_model=list[ParentescoRespuestaDetallada],
     description="""
 Obtiene una lista de todas 
 las relaciones de parentesco asociadas a un usuario específico, ya sea como solicitante o destinatario.

--- a/app/usuarios/docs/solicitud_parentesco_doc.py
+++ b/app/usuarios/docs/solicitud_parentesco_doc.py
@@ -5,11 +5,12 @@
 
 from fastapi import Body
 from typing import Annotated
-from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear
+from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoRespuesta
 
 
 solicitar_parentesco_docs = dict(
     summary="Solicitar parentesco entre usuarios",
+        response_model=ParentescoRespuesta,
     description="""
 Crea una solicitud de parentesco entre dos usuarios del sistema.
 
@@ -26,10 +27,11 @@ Crea una solicitud de parentesco entre dos usuarios del sistema.
             "content": {
                 "application/json": {
                     "example": {
-                        "mensaje": "Solicitud de parentesco enviada exitosamente.",
+                        "codigo": 1,
                         "codigo_solicitante": 1,
                         "codigo_destinatario": 2,
                         "tipo_parentesco": "hermano (a)",
+                        "estado": "pendiente"
                     }
                 }
             },

--- a/app/usuarios/docs/solicitud_parentesco_doc.py
+++ b/app/usuarios/docs/solicitud_parentesco_doc.py
@@ -71,7 +71,7 @@ solicitar_parentesco_body = Annotated[
                 "value": {
                     "codigo_solicitante": 1,
                     "codigo_destinatario": 2,
-                    "tipo_parentesco": "hermano",
+                    "tipo_parentesco": "hermano (a)",
                 },
             },
             "ejemplo_completo": {

--- a/app/usuarios/repository/parentesco_repositorio.py
+++ b/app/usuarios/repository/parentesco_repositorio.py
@@ -54,3 +54,21 @@ class ParentescoRepositorio:
             )
         )
         return result.scalars().all()
+    
+    async def obtener_parentesco_por_id(self, id_parentesco: int) -> Parentesco | None:
+        """Obtiene un parentesco por su ID."""
+        result = await self.db.execute(
+            select(Parentesco).where(Parentesco.id == id_parentesco)
+        )
+        return result.scalar_one_or_none()
+    
+    async def actualizar_estado_parentesco(self, id_parentesco: int, nuevo_estado: EstadoSolicitudParentesco) -> Parentesco:
+        """Actualiza el estado de una solicitud de parentesco."""
+        parentesco = await self.obtener_parentesco_por_id(id_parentesco)
+        if not parentesco:
+            raise ValueError("La solicitud de parentesco no existe.")
+        parentesco.estado = nuevo_estado
+        self.db.add(parentesco)
+        await self.db.commit()
+        await self.db.refresh(parentesco)
+        return parentesco

--- a/app/usuarios/repository/parentesco_repositorio.py
+++ b/app/usuarios/repository/parentesco_repositorio.py
@@ -5,6 +5,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 from app.usuarios.models.parentesco import Parentesco, EstadoSolicitudParentesco
 from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoLista
 
@@ -49,22 +50,33 @@ class ParentescoRepositorio:
     async def listar_parentescos_usuario(self, codigo_usuario: int) -> list[ParentescoLista]:
         """Lista todas las relaciones de parentesco de un usuario."""
         result = await self.db.execute(
-            select(Parentesco).where(
-                (Parentesco.codigo_destinatario == codigo_usuario) | (Parentesco.codigo_solicitante == codigo_usuario),
-            )
+            select(Parentesco)
+            .where(
+                (Parentesco.codigo_destinatario == codigo_usuario) | (Parentesco.codigo_solicitante == codigo_usuario),)
+            .options(selectinload(Parentesco.solicitante), selectinload(Parentesco.destinatario))
         )
         return result.scalars().all()
     
-    async def obtener_parentesco_por_id(self, id_parentesco: int) -> Parentesco | None:
-        """Obtiene un parentesco por su ID."""
+    async def obtener_parentesco_por_id_detallado(self, id_parentesco: int) -> Parentesco | None:
+        """Obtiene un parentesco por su ID con sus relaciones cargadas."""
         result = await self.db.execute(
-            select(Parentesco).where(Parentesco.id == id_parentesco)
+            select(Parentesco)
+            .where(Parentesco.codigo == id_parentesco)
+            .options(selectinload(Parentesco.solicitante), selectinload(Parentesco.destinatario))
+        )
+        return result.scalar_one_or_none()
+    
+    async def obtener_parentesco_por_id(self, id_parentesco: int) -> Parentesco | None:
+        """Obtiene un parentesco por su ID con sus relaciones cargadas."""
+        result = await self.db.execute(
+            select(Parentesco)
+            .where(Parentesco.codigo == id_parentesco)
         )
         return result.scalar_one_or_none()
     
     async def actualizar_estado_parentesco(self, id_parentesco: int, nuevo_estado: EstadoSolicitudParentesco) -> Parentesco:
         """Actualiza el estado de una solicitud de parentesco."""
-        parentesco = await self.obtener_parentesco_por_id(id_parentesco)
+        parentesco = await self.obtener_parentesco_por_id_detallado(id_parentesco)
         if not parentesco:
             raise ValueError("La solicitud de parentesco no existe.")
         parentesco.estado = nuevo_estado

--- a/app/usuarios/repository/parentesco_repositorio.py
+++ b/app/usuarios/repository/parentesco_repositorio.py
@@ -4,7 +4,7 @@
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import select
+from sqlalchemy import select, or_
 from sqlalchemy.orm import selectinload
 from app.usuarios.models.parentesco import Parentesco, EstadoSolicitudParentesco
 from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoRespuesta
@@ -26,22 +26,30 @@ class ParentescoRepositorio:
         return parentesco
 
     async def existe_solicitud_parentesco(self, codigo_solicitante: int, codigo_destinatario: int) -> bool:
-        """Verifica si ya existe una solicitud de parentesco entre dos usuarios."""
+        """Verifica si ya existe una solicitud de parentesco bidireccional entre dos usuarios."""
         result = await self.db.execute(
             select(Parentesco).where(
-                Parentesco.codigo_solicitante == codigo_solicitante,
-                Parentesco.codigo_destinatario == codigo_destinatario,
+                or_(
+                    # Caso 1: A solicita a B
+                    (Parentesco.codigo_solicitante == codigo_solicitante) & (Parentesco.codigo_destinatario == codigo_destinatario),
+                    # Caso 2: B solicita a A
+                    (Parentesco.codigo_solicitante == codigo_destinatario) & (Parentesco.codigo_destinatario == codigo_solicitante)
+                ),
                 Parentesco.estado == EstadoSolicitudParentesco.pendiente
             )
         )
         return result.scalar_one_or_none() is not None
     
     async def existe_parentesco(self, codigo_solicitante: int, codigo_destinatario: int) -> bool:
-        """Verifica si ya existe una relacion de parentesco entre dos usuarios."""
+        """Verifica si ya existe una relación de parentesco aceptada bidireccional entre dos usuarios."""
         result = await self.db.execute(
             select(Parentesco).where(
-                Parentesco.codigo_solicitante == codigo_solicitante,
-                Parentesco.codigo_destinatario == codigo_destinatario,
+                or_(
+                    # Caso 1: A y B aceptaron parentesco (A solicitó a B)
+                    (Parentesco.codigo_solicitante == codigo_solicitante) & (Parentesco.codigo_destinatario == codigo_destinatario),
+                    # Caso 2: A y B aceptaron parentesco (B solicitó a A)
+                    (Parentesco.codigo_solicitante == codigo_destinatario) & (Parentesco.codigo_destinatario == codigo_solicitante)
+                ),
                 Parentesco.estado == EstadoSolicitudParentesco.aceptada   
             )
         )

--- a/app/usuarios/repository/parentesco_repositorio.py
+++ b/app/usuarios/repository/parentesco_repositorio.py
@@ -7,7 +7,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 from app.usuarios.models.parentesco import Parentesco, EstadoSolicitudParentesco
-from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoLista
+from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoRespuesta
 
 class ParentescoRepositorio:
 
@@ -47,7 +47,7 @@ class ParentescoRepositorio:
         )
         return result.scalar_one_or_none() is not None
     
-    async def listar_parentescos_usuario(self, codigo_usuario: int) -> list[ParentescoLista]:
+    async def listar_parentescos_usuario(self, codigo_usuario: int) -> list[ParentescoRespuesta]:
         """Lista todas las relaciones de parentesco de un usuario."""
         result = await self.db.execute(
             select(Parentesco)

--- a/app/usuarios/repository/parentesco_repositorio.py
+++ b/app/usuarios/repository/parentesco_repositorio.py
@@ -52,7 +52,7 @@ class ParentescoRepositorio:
         result = await self.db.execute(
             select(Parentesco)
             .where(
-                (Parentesco.codigo_destinatario == codigo_usuario) | (Parentesco.codigo_solicitante == codigo_usuario),)
+                (Parentesco.codigo_destinatario == codigo_usuario) | (Parentesco.codigo_solicitante == codigo_usuario), Parentesco.estado != EstadoSolicitudParentesco.expirada)
             .options(selectinload(Parentesco.solicitante), selectinload(Parentesco.destinatario))
         )
         return result.scalars().all()

--- a/app/usuarios/schemas/parentesco_esquemas.py
+++ b/app/usuarios/schemas/parentesco_esquemas.py
@@ -28,9 +28,9 @@ class ParentescoRespuesta(BaseModel):
     model_config = {"from_attributes": True}
 
 class ParentescoRespuestaDetallada(BaseModel):
-    codigo: int = Field(alias="pa_codigo")
-    tipo_parentesco: TipoParentesco = Field(alias="pa_tipo_parentesco")
-    estado: EstadoSolicitudParentesco = Field(alias="pa_estado")
+    codigo: int 
+    tipo_parentesco: TipoParentesco 
+    estado: EstadoSolicitudParentesco 
     solicitante: UsuarioResumen
     destinatario: UsuarioResumen
     model_config = {"from_attributes": True, "populate_by_name": True}

--- a/app/usuarios/schemas/parentesco_esquemas.py
+++ b/app/usuarios/schemas/parentesco_esquemas.py
@@ -17,15 +17,6 @@ class ParentescoCrear(BaseModel):
     codigo_destinatario: int
     tipo_parentesco: TipoParentesco
 
-class ParentescoRespuesta(BaseModel):
-    codigo: int
-    fecha_creacion: date
-    estado: EstadoSolicitudParentesco
-    codigo_solicitante: int
-    codigo_destinatario: int
-    tipo_parentesco: TipoParentesco
-
-    model_config = {"from_attributes": True}
 
 class ParentescoRespuestaDetallada(BaseModel):
     codigo: int 
@@ -36,7 +27,7 @@ class ParentescoRespuestaDetallada(BaseModel):
     model_config = {"from_attributes": True, "populate_by_name": True}
 
 
-class ParentescoLista(BaseModel):
+class ParentescoRespuesta(BaseModel):
     codigo: int
     codigo_solicitante: int
     codigo_destinatario: int

--- a/app/usuarios/services/usuario_servicio.py
+++ b/app/usuarios/services/usuario_servicio.py
@@ -7,6 +7,7 @@ de datos requeridas antes de interactuar con la capa de repositorio.
 from passlib.context import CryptContext
 from sqlalchemy import select
 
+from app.usuarios.models.parentesco import EstadoSolicitudParentesco
 from app.usuarios.models.usuario import Usuario
 from app.usuarios.repository.parentesco_repositorio import ParentescoRepositorio
 from app.usuarios.repository.usuario_repositorio import UsuarioRepositorio
@@ -144,6 +145,25 @@ class UsuarioServicio:
         if not self.repositorio_parentesco:
             raise RuntimeError("Repositorio de parentesco no inicializado.")
         return await self.repositorio_parentesco.existe_parentesco(codigo_solicitante, codigo_destinatario)
+
+    async def aceptar_solicitud_parentesco(self, codigo_solicitud:int):
+        """Acepta una solicitud de parentesco pendiente."""
+        solicitud = await self.repositorio_parentesco.obtener_parentesco_por_id(codigo_solicitud)
+        if not solicitud:
+            raise ValueError("La solicitud de parentesco no existe.")
+        if solicitud.estado != EstadoSolicitudParentesco.pendiente:
+            raise ValueError("Solo se pueden aceptar solicitudes que estén en estado pendiente.")
+        return await self.repositorio_parentesco.actualizar_estado_parentesco(codigo_solicitud, EstadoSolicitudParentesco.aceptada)
+
+
+    async def rechazar_solicitud_parentesco(self, codigo_solicitud:int):
+        """Rechaza una solicitud de parentesco pendiente."""
+        solicitud = await self.repositorio_parentesco.obtener_parentesco_por_id(codigo_solicitud)
+        if not solicitud:
+            raise ValueError("La solicitud de parentesco no existe.")
+        if solicitud.estado != EstadoSolicitudParentesco.pendiente:
+            raise ValueError("Solo se pueden rechazar solicitudes que estén en estado pendiente.")
+        return await self.repositorio_parentesco.actualizar_estado_parentesco(codigo_solicitud, EstadoSolicitudParentesco.rechazada)
 
     async def existe_solicitud_parentesco(self, codigo_solicitante: int, codigo_destinatario: int) -> bool:
         """Verifica si ya existe una solicitud de parentesco entre dos usuarios."""

--- a/app/usuarios/services/usuario_servicio.py
+++ b/app/usuarios/services/usuario_servicio.py
@@ -12,7 +12,7 @@ from app.usuarios.models.usuario import Usuario
 from app.usuarios.repository.parentesco_repositorio import ParentescoRepositorio
 from app.usuarios.repository.usuario_repositorio import UsuarioRepositorio
 from app.usuarios.schemas.usuario_esquemas import UsuarioConsultaColonia, UsuarioCrear, UsuarioResumen
-from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoLista, ParentescoRespuestaDetallada
+from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoRespuesta, ParentescoRespuestaDetallada
 
 # Contexto para el cifrado y verificación de contraseñas utilizando el algoritmo bcrypt.
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -170,7 +170,7 @@ class UsuarioServicio:
         if solicitud.estado != EstadoSolicitudParentesco.pendiente:
             raise ValueError("Solo se pueden aceptar solicitudes que estén en estado pendiente.")
         parentesco = await self.repositorio_parentesco.actualizar_estado_parentesco(codigo_solicitud, EstadoSolicitudParentesco.aceptada)
-        return ParentescoLista(
+        return ParentescoRespuesta(
             codigo=parentesco.codigo,
             codigo_solicitante=parentesco.codigo_solicitante,
             codigo_destinatario=parentesco.codigo_destinatario,
@@ -187,7 +187,7 @@ class UsuarioServicio:
         if solicitud.estado != EstadoSolicitudParentesco.pendiente:
             raise ValueError("Solo se pueden rechazar solicitudes que estén en estado pendiente.")
         parentesco = await self.repositorio_parentesco.actualizar_estado_parentesco(codigo_solicitud, EstadoSolicitudParentesco.rechazada)
-        return ParentescoLista(
+        return ParentescoRespuesta(
             codigo=parentesco.codigo,
             codigo_solicitante=parentesco.codigo_solicitante,
             codigo_destinatario=parentesco.codigo_destinatario,
@@ -222,7 +222,14 @@ class UsuarioServicio:
         if await self.existe_solicitud_parentesco(parentesco_crear.codigo_solicitante, parentesco_crear.codigo_destinatario):
             raise ValueError("Ya existe una solicitud de parentesco pendiente entre estos usuarios.")
 
-        return await self.repositorio_parentesco.solicitar_parentesco(parentesco_crear)
+        solicitud_parentesco =  await self.repositorio_parentesco.solicitar_parentesco(parentesco_crear)
+        return ParentescoRespuesta(
+            codigo=solicitud_parentesco.codigo,
+            codigo_solicitante=solicitud_parentesco.codigo_solicitante,
+            codigo_destinatario=solicitud_parentesco.codigo_destinatario,
+            tipo_parentesco=solicitud_parentesco.tipo_parentesco,
+            estado=solicitud_parentesco.estado
+        )
     async def obtener_usuario_por_id(self, us_id: int) -> Usuario | None:
         """
         Obtiene un usuario por su ID.

--- a/app/usuarios/services/usuario_servicio.py
+++ b/app/usuarios/services/usuario_servicio.py
@@ -11,13 +11,29 @@ from app.usuarios.models.parentesco import EstadoSolicitudParentesco
 from app.usuarios.models.usuario import Usuario
 from app.usuarios.repository.parentesco_repositorio import ParentescoRepositorio
 from app.usuarios.repository.usuario_repositorio import UsuarioRepositorio
-from app.usuarios.schemas.usuario_esquemas import UsuarioConsultaColonia, UsuarioCrear
-from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear
+from app.usuarios.schemas.usuario_esquemas import UsuarioConsultaColonia, UsuarioCrear, UsuarioResumen
+from app.usuarios.schemas.parentesco_esquemas import ParentescoCrear, ParentescoLista, ParentescoRespuestaDetallada
 
 # Contexto para el cifrado y verificación de contraseñas utilizando el algoritmo bcrypt.
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
+def mapear_usuario_a_resumen(usuario: Usuario) -> UsuarioResumen:
+    """Función auxiliar para mapear un objeto Usuario a UsuarioResumen."""
+    return UsuarioResumen(
+        codigo=usuario.us_codigo,
+        nombre=usuario.us_nombre,
+        apellido=usuario.us_apellido
+    )
 
+def mapear_parentesco_a_respuesta_detallada(parentesco, solicitante: Usuario, destinatario: Usuario) -> ParentescoRespuestaDetallada:
+    """Función auxiliar para mapear un objeto Parentesco a ParentescoRespuestaDetallada."""
+    return ParentescoRespuestaDetallada(
+        codigo=parentesco.codigo,
+        tipo_parentesco=parentesco.tipo_parentesco,
+        estado=parentesco.estado,
+        solicitante= mapear_usuario_a_resumen(solicitante),
+        destinatario= mapear_usuario_a_resumen(destinatario)
+    )
 class UsuarioServicio:
     """
     Servicio para gestionar la lógica de negocio de los usuarios.
@@ -153,7 +169,14 @@ class UsuarioServicio:
             raise ValueError("La solicitud de parentesco no existe.")
         if solicitud.estado != EstadoSolicitudParentesco.pendiente:
             raise ValueError("Solo se pueden aceptar solicitudes que estén en estado pendiente.")
-        return await self.repositorio_parentesco.actualizar_estado_parentesco(codigo_solicitud, EstadoSolicitudParentesco.aceptada)
+        parentesco = await self.repositorio_parentesco.actualizar_estado_parentesco(codigo_solicitud, EstadoSolicitudParentesco.aceptada)
+        return ParentescoLista(
+            codigo=parentesco.codigo,
+            codigo_solicitante=parentesco.codigo_solicitante,
+            codigo_destinatario=parentesco.codigo_destinatario,
+            tipo_parentesco=parentesco.tipo_parentesco,
+            estado=parentesco.estado
+        )
 
 
     async def rechazar_solicitud_parentesco(self, codigo_solicitud:int):
@@ -163,8 +186,19 @@ class UsuarioServicio:
             raise ValueError("La solicitud de parentesco no existe.")
         if solicitud.estado != EstadoSolicitudParentesco.pendiente:
             raise ValueError("Solo se pueden rechazar solicitudes que estén en estado pendiente.")
-        return await self.repositorio_parentesco.actualizar_estado_parentesco(codigo_solicitud, EstadoSolicitudParentesco.rechazada)
+        parentesco = await self.repositorio_parentesco.actualizar_estado_parentesco(codigo_solicitud, EstadoSolicitudParentesco.rechazada)
+        return ParentescoLista(
+            codigo=parentesco.codigo,
+            codigo_solicitante=parentesco.codigo_solicitante,
+            codigo_destinatario=parentesco.codigo_destinatario,
+            tipo_parentesco=parentesco.tipo_parentesco,
+            estado=parentesco.estado
+        )
 
+    async def obtener_parentesco_por_id(self, id_parentesco: int):
+        """Obtiene un parentesco por su ID."""
+        return await self.repositorio_parentesco.obtener_parentesco_por_id_detallado(id_parentesco)
+    
     async def existe_solicitud_parentesco(self, codigo_solicitante: int, codigo_destinatario: int) -> bool:
         """Verifica si ya existe una solicitud de parentesco entre dos usuarios."""
         if not self.repositorio_parentesco:
@@ -203,7 +237,16 @@ class UsuarioServicio:
     
     async def listar_parentescos_usuario(self, codigo_usuario: int):
         """Lista todas las relaciones de parentesco de un usuario."""
-        return await self.repositorio_parentesco.listar_parentescos_usuario(codigo_usuario)
+
+        parentescos = await self.repositorio_parentesco.listar_parentescos_usuario(codigo_usuario)
+        return [mapear_parentesco_a_respuesta_detallada(p, p.solicitante, p.destinatario) for p in parentescos]
+    
+    async def obtener_parentesco_por_id(self, codigo_parentesco: int):
+        """Obtiene un parentesco específico por su ID."""
+        parentesco = await self.repositorio_parentesco.obtener_parentesco_por_id_detallado(codigo_parentesco)
+        if not parentesco:
+            raise ValueError("La solicitud de parentesco no existe.")
+        return mapear_parentesco_a_respuesta_detallada(parentesco, parentesco.solicitante, parentesco.destinatario)
     
     async def buscar_por_colonia(self, colonia: int) -> list[Usuario]:
         """Busca usuarios miembros por colonia."""

--- a/tests/usuarios/solicitud_parentesco_tests.py
+++ b/tests/usuarios/solicitud_parentesco_tests.py
@@ -25,7 +25,6 @@ def repositorio_parentesco():
     repo = MagicMock()
     repo.existe_parentesco = AsyncMock(return_value=False)
     repo.existe_solicitud_parentesco = AsyncMock(return_value=False)
-    repo.solicitar_parentesco = AsyncMock(return_value={"mensaje": "Solicitud creada exitosamente."})
     return repo
 
 
@@ -72,10 +71,17 @@ def configurar_existe_usuario(repositorio, solicitante: bool, destinatario: bool
 async def test_solicitar_parentesco_exitoso(servicio, repositorio, repositorio_parentesco, parentesco_crear):
     """La solicitud se crea correctamente cuando todos los datos son válidos."""
     configurar_existe_usuario(repositorio, solicitante=True, destinatario=True)
+    
+    solicitud_mock = MagicMock()
+    solicitud_mock.estado = "pendiente"
+    solicitud_mock.codigo_solicitante = parentesco_crear.codigo_solicitante
+    solicitud_mock.codigo_destinatario = parentesco_crear.codigo_destinatario
+    solicitud_mock.tipo_parentesco = parentesco_crear.tipo_parentesco
+    repositorio_parentesco.solicitar_parentesco = AsyncMock(return_value=solicitud_mock)
 
     resultado = await servicio.solicitar_parentesco(parentesco_crear)
 
-    assert resultado == {"mensaje": "Solicitud creada exitosamente."}
+    assert resultado == solicitud_mock
     repositorio_parentesco.solicitar_parentesco.assert_awaited_once_with(parentesco_crear)
 
 
@@ -128,3 +134,57 @@ async def test_solicitar_parentesco_ya_existe_solicitud(servicio, repositorio, r
 
     with pytest.raises(ValueError, match="Ya existe una solicitud de parentesco pendiente entre estos usuarios."):
         await servicio.solicitar_parentesco(parentesco_crear)
+
+@pytest.mark.asyncio
+async def test_aceptar_solicitud_parentesco_exitoso(servicio, repositorio_parentesco):
+    """Acepta una solicitud de parentesco pendiente correctamente."""
+    codigo_solicitud = 1
+    solicitud_mock = MagicMock()
+    solicitud_mock.estado = "pendiente"
+    solicitud_mock_aceptada = MagicMock()
+    solicitud_mock_aceptada.estado = "aceptada"
+    repositorio_parentesco.obtener_parentesco_por_id = AsyncMock(return_value=solicitud_mock)
+    repositorio_parentesco.actualizar_estado_parentesco = AsyncMock(return_value=solicitud_mock_aceptada)
+
+    resultado = await servicio.aceptar_solicitud_parentesco(codigo_solicitud)
+
+    assert resultado == solicitud_mock_aceptada
+    repositorio_parentesco.obtener_parentesco_por_id.assert_awaited_once_with(codigo_solicitud)
+    repositorio_parentesco.actualizar_estado_parentesco.assert_awaited_once_with(codigo_solicitud, "aceptada")
+
+@pytest.mark.asyncio
+async def test_rechazar_solicitud_parentesco_exitoso(servicio, repositorio_parentesco):
+    """Rechaza una solicitud de parentesco pendiente correctamente."""
+    codigo_solicitud = 1
+    solicitud_mock = MagicMock()
+    solicitud_mock.estado = "pendiente"
+    solicitud_mock_rechazada = MagicMock()
+    solicitud_mock_rechazada.estado = "rechazada"
+    repositorio_parentesco.obtener_parentesco_por_id = AsyncMock(return_value=solicitud_mock)
+    repositorio_parentesco.actualizar_estado_parentesco = AsyncMock(return_value=solicitud_mock_rechazada)
+
+    resultado = await servicio.rechazar_solicitud_parentesco(codigo_solicitud)
+
+    assert resultado == solicitud_mock_rechazada
+    repositorio_parentesco.obtener_parentesco_por_id.assert_awaited_once_with(codigo_solicitud)
+    repositorio_parentesco.actualizar_estado_parentesco.assert_awaited_once_with(codigo_solicitud, "rechazada")
+
+@pytest.mark.asyncio
+async def test_aceptar_solicitud_parentesco_no_existe(servicio, repositorio_parentesco):
+    """Lanza ValueError al intentar aceptar una solicitud de parentesco que no existe."""
+    codigo_solicitud = 999
+    repositorio_parentesco.obtener_parentesco_por_id = AsyncMock(return_value=None)
+
+    with pytest.raises(ValueError, match="La solicitud de parentesco no existe."):
+        await servicio.aceptar_solicitud_parentesco(codigo_solicitud)
+
+@pytest.mark.asyncio
+async def test_rechazar_solicitud_parentesco_estado_invalido(servicio, repositorio_parentesco):
+    """Lanza ValueError al intentar rechazar una solicitud de parentesco que no está en estado pendiente."""
+    codigo_solicitud = 1
+    solicitud_mock = MagicMock()
+    solicitud_mock.estado = "aceptada"
+    repositorio_parentesco.obtener_parentesco_por_id = AsyncMock(return_value=solicitud_mock)
+
+    with pytest.raises(ValueError, match="Solo se pueden rechazar solicitudes que estén en estado pendiente."):
+        await servicio.rechazar_solicitud_parentesco(codigo_solicitud)


### PR DESCRIPTION
## Descripción del Cambio
Esta PR es una copia de #59
Esta PR implementa las funciones de aceptar y rechazar solicitudes de parentescos, además, se corrige el esquema de respuesta al consultar parentescos e implementa la función de obtener parentesco por id. 

## ID de la Historia de Usuario
- Estas funcionalidades no tienen códigos de HU asignadas. 

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [x] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%?
- [x] ¿Las validaciones de negocio (Documento > 0, Celular 10 dígitos, etc.) están implementadas?

## ¿Cómo probar este cambio?
**Backend:**
1. Levantar con Docker.
2. Probar en Swagger (`/docs`) los siguientes endpoints:
- /api/v1/usuario/parentesco/{parentesco_id}
- /api/v1/usuario/{codigo_usuario}/parentescos (se corrigió el modelo de respuesta)
- /api/v1/usuario/solicitud-parentesco/aceptar/{solicitud_id}
- /api/v1/usuario/solicitud-parentesco/rechazar/{solicitud_id}