### PR TITLE
feat[3GC-6]: permitir que usuarios sin colonia sean asignados como lider al …

### DIFF
--- a/app/colonias/excepciones/excepciones.py
+++ b/app/colonias/excepciones/excepciones.py
@@ -54,6 +54,13 @@ class UsuarioNoExistente(HTTPException):
             status_code= status.HTTP_404_NOT_FOUND,
             detail=f"Usuario con ID {usuario_id} no encontrado.")
 
+class UsuarioYaTieneColonia(HTTPException):
+    def __init__(self, usuario_id: int, colonia_actual:int, colonia_nueva:int):
+        self.usuario_id = usuario_id
+        super().__init__(
+            status_code= status.HTTP_409_CONFLICT,
+            detail=f"Usuario con ID {usuario_id} pertenece a la colonia {colonia_actual}, no puede ser asignado como lider de la colonia {colonia_nueva}.")
+
 class UsuarioNoEsMiembroColonia(HTTPException):
     def __init__(self, usuario_id, colonia_id):
         self.usuario_id = usuario_id

--- a/app/colonias/repositories/colonia_repository.py
+++ b/app/colonias/repositories/colonia_repository.py
@@ -187,7 +187,6 @@ class ColoniaRepository:
         Cambia el líder de una colonia existente, actualizando el campo lider de la colonia 
         y el rol de los usuarios involucrados.
         Parámetros:
-            db (AsyncSession): Sesión activa de SQLAlchemy.
             colonia_codigo (int): Código de la colonia a actualizar.
             nuevo_lider_id (int): ID del nuevo líder a asignar.
         Retorna:
@@ -198,6 +197,7 @@ class ColoniaRepository:
         usuario_antiguo.ro_codigo = 1
         usuario_nuevo = await self.db.get(Usuario, nuevo_lider_id)
         usuario_nuevo.ro_codigo = 2
+        usuario_nuevo.co_codigo = colonia_codigo
         colonia.lider = nuevo_lider_id
         await self.db.commit()
         await self.db.refresh(colonia)

--- a/app/colonias/services/colonia_services.py
+++ b/app/colonias/services/colonia_services.py
@@ -4,7 +4,7 @@ Coordina la validación de reglas de negocio y la interacción con el
 repositorio de colonias, garantizando la integridad de los datos antes 
 de su persistencia en la base de datos.
 """
-from app.colonias.excepciones.excepciones import ColoniaInactiva, ColoniaNoExistente
+from app.colonias.excepciones.excepciones import ColoniaInactiva, ColoniaNoExistente, UsuarioYaTieneColonia
 from app.colonias.models.colonia_model import ColoniaEstado
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.colonias.excepciones.excepciones import (
@@ -155,7 +155,6 @@ class ColoniaService:
         Cambia el líder de una colonia existente. Verifica que la colonia exista, tenga un líder asignado previamente,
         que el nuevo líder exista, sea miembro de la colonia y sea diferente al líder actual antes de realizar el cambio.
         Parámetros:
-            db (Session): Sesión activa de SQLAlchemy.
             colonia_codigo (int): Código de la colonia a actualizar.
             nuevo_lider_id (int): ID del nuevo líder a asignar.
         Retorna:
@@ -165,7 +164,7 @@ class ColoniaService:
             HTTPException 409: Si la colonia no tiene un líder asignado, el nuevo líder no es 
                             miembro de la colonia o ya es el líder actual.
         """
-   
+        
         colonia = await self.repositorio.obtener_colonia_por_id(colonia_codigo)
         if not colonia:
             raise ColoniaNoExistente(colonia_codigo)
@@ -178,8 +177,8 @@ class ColoniaService:
         if not usuario_nuevo_lider:
             raise UsuarioNoExistente(nuevo_lider_id)
         
-        if usuario_nuevo_lider.co_codigo != colonia_codigo:
-            raise UsuarioNoEsMiembroColonia(nuevo_lider_id, colonia_codigo)
+        if usuario_nuevo_lider.co_codigo is not None and usuario_nuevo_lider.co_codigo != colonia_codigo:
+            raise UsuarioYaTieneColonia(usuario_nuevo_lider.us_codigo, usuario_nuevo_lider.co_codigo, colonia_codigo)
         
         if colonia.lider == nuevo_lider_id:
             raise UsuarioYaEsLider(nuevo_lider_id, colonia_codigo)

--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -4,6 +4,7 @@ from datetime import datetime, date
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy import func, select
+from passlib.context import CryptContext
 
 import sys
 import os
@@ -29,6 +30,10 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 settings = get_settings()
+
+# Contexto para encriptar contraseñas con bcrypt
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+CONTRASENA_ENCRIPTADA = pwd_context.hash("usuario123")
 
 
 async def seed_data() -> None:
@@ -99,16 +104,31 @@ async def seed_data() -> None:
             # 2. CREAR USUARIOS (2 por colonia)
             # ═════════════════════════════════════════
             logger.info("Creando usuarios...")
-            
             usuarios = []
             usuarios_data = [
+                #admin
+                {
+                    "us_tipo_doc": TipoDoc.CC,
+                    "us_documento": "11111",
+                    "us_celular": "3007777777",
+                    "us_correo": "admin@email.com",
+                    "us_contrasenia": CONTRASENA_ENCRIPTADA,
+                    "us_nombre": "admin",
+                    "us_apellido": "admin",
+                    "us_genero": Genero.M,
+                    "us_fecha_nacimiento": date(1990, 5, 15),
+                    "us_pais": "Colombia",
+                    "us_departamento": "Antioquia",
+                    "us_ciudad": "Medellín",
+                    "ro_codigo": 3,  # admin
+                },
                 # Colonia 1
                 {
                     "us_tipo_doc": TipoDoc.CC,
                     "us_documento": "1001234567",
                     "us_celular": "3001111111",
                     "us_correo": "juan.perez@email.com",
-                    "us_contrasenia": "hashed_password_1",
+                    "us_contrasenia": CONTRASENA_ENCRIPTADA,
                     "us_nombre": "Juan",
                     "us_apellido": "Pérez",
                     "us_genero": Genero.M,
@@ -124,7 +144,7 @@ async def seed_data() -> None:
                     "us_documento": "1002345678",
                     "us_celular": "3002222222",
                     "us_correo": "maria.garcia@email.com",
-                    "us_contrasenia": "hashed_password_2",
+                    "us_contrasenia": CONTRASENA_ENCRIPTADA,
                     "us_nombre": "María",
                     "us_apellido": "García",
                     "us_genero": Genero.OTRO,
@@ -141,7 +161,7 @@ async def seed_data() -> None:
                     "us_documento": "1003456789",
                     "us_celular": "3003333333",
                     "us_correo": "carlos.lopez@email.com",
-                    "us_contrasenia": "hashed_password_3",
+                    "us_contrasenia": CONTRASENA_ENCRIPTADA,
                     "us_nombre": "Carlos",
                     "us_apellido": "López",
                     "us_genero": Genero.M,
@@ -157,7 +177,7 @@ async def seed_data() -> None:
                     "us_documento": "1004567890",
                     "us_celular": "3004444444",
                     "us_correo": "ana.martinez@email.com",
-                    "us_contrasenia": "hashed_password_4",
+                    "us_contrasenia": CONTRASENA_ENCRIPTADA,
                     "us_nombre": "Ana",
                     "us_apellido": "Martínez",
                     "us_genero": Genero.F,
@@ -174,7 +194,7 @@ async def seed_data() -> None:
                     "us_documento": "1005678901",
                     "us_celular": "3005555555",
                     "us_correo": "luis.torres@email.com",
-                    "us_contrasenia": "hashed_password_5",
+                    "us_contrasenia": CONTRASENA_ENCRIPTADA,
                     "us_nombre": "Luis",
                     "us_apellido": "Torres",
                     "us_genero": Genero.M,
@@ -190,7 +210,7 @@ async def seed_data() -> None:
                     "us_documento": "1006789012",
                     "us_celular": "3006666666",
                     "us_correo": "diana.cruz@email.com",
-                    "us_contrasenia": "hashed_password_6",
+                    "us_contrasenia": CONTRASENA_ENCRIPTADA,
                     "us_nombre": "Diana",
                     "us_apellido": "Cruz",
                     "us_genero": Genero.F,
@@ -210,6 +230,23 @@ async def seed_data() -> None:
             
             await db.flush()
             logger.info(f"✓ {len(usuarios)} usuarios creados")
+
+            # ═════════════════════════════════════════
+            # 2.5 ESTABLECER LÍDERES DE COLONIAS
+            # ═════════════════════════════════════════
+            logger.info("Estableciendo líderes de colonias...")
+            
+            # Colonia 1: Líder María 
+            colonias[0].lider = usuarios[2].us_codigo
+            
+            # Colonia 2: Líder Ana 
+            colonias[1].lider = usuarios[3].us_codigo
+            
+            # Colonia 3: Líder Diana 
+            colonias[2].lider = usuarios[6].us_codigo
+            
+            await db.flush()
+            logger.info("✓ Líderes de colonias establecidos")
 
             # ═════════════════════════════════════════
             # 3. CREAR RETORNO
@@ -312,7 +349,7 @@ async def seed_data() -> None:
             logger.info("✓ Usuarios asociados a grupos de retorno")
 
             # ═════════════════════════════════════════
-            # 6. ASOCIAR PERSONAS A GRUPOS
+            # 7. ASOCIAR PERSONAS A GRUPOS
             # ═════════════════════════════════════════
             logger.info("Asociando personas a grupos de retorno...")
             
@@ -334,7 +371,7 @@ async def seed_data() -> None:
             logger.info("✓ Personas asociadas a grupos de retorno")
 
             # ═════════════════════════════════════════
-            # 7. CREAR INSCRIPCIONES INDIVIDUALES
+            # 8. CREAR INSCRIPCIONES INDIVIDUALES
             # ═════════════════════════════════════════
             logger.info("Creando inscripciones individuales...")
             
@@ -392,7 +429,7 @@ async def seed_data() -> None:
             logger.info(f"✓ {len(inscripciones)} inscripciones individuales creadas")
 
             # ═════════════════════════════════════════
-            # 8. CREAR INSCRIPCIONES GRUPALES
+            # 9. CREAR INSCRIPCIONES GRUPALES
             # ═════════════════════════════════════════
             logger.info("Creando inscripciones grupales...")
             


### PR DESCRIPTION

## Descripción del Cambio

Esta PR actualiza una de las validaciones de cambiar líder de colonia, ahora, es posible establecer como líder de colonia a un usuario sin colonia durante el cambio. Adicionalmente, en los datos semillas se agrego un usuario admin, además se cambiaron las contraseñas de los usuarios para respetar el algoritmo de encriptación implementado en el login. 

## ID de la Historia de Usuario
- **HU:** 3GC-6: Cambiar líder de colonia 

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [x] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%?
- [x] ¿Las validaciones de negocio (Documento > 0, Celular 10 dígitos, etc.) están implementadas?

## ¿Cómo probar este cambio?
**Backend:**
1. Levantar con Docker.
2. Probar en Swagger (`/docs`), siguiendo los siguientes pasos, teniendo los datos semilla como base:
- crear un nuevo usuario 
- cambiar el líder de una colonia por el nuevo usuario
resultado: El nuevo usuario debe ser asociado a la colonia y establecido como líder, además el líder anterior debe ser revocado de su cargo. 