### PR TITLE
validacion: no generar reportes sin registros

### DIFF
--- a/app/reportes/api/v1/endpoints/reportes_router.py
+++ b/app/reportes/api/v1/endpoints/reportes_router.py
@@ -16,6 +16,8 @@ from app.reportes.repositories.grupo_retorno_reporte_repositorio import GrupoRep
 from app.reportes.repositories.persona_reporte_repositorio import PersonaReporteRepositorio
 from app.reportes.repositories.usuario_retorno_reporte_repositorio import UsuarioRetornoReporteRepositorio
 from app.reportes.services.reportes_service import ReportesService
+from app.retornos.repositorios.registro_retorno_grupo_repositorio import RegistroRetornoGrupoRepositorio
+from app.retornos.repositorios.registro_retorno_repositorio import RegistroRetornoRepositorio
 from app.usuarios.auth_dependencies import require_roles
 from app.usuarios.models.usuario import Usuario
 
@@ -24,9 +26,13 @@ def get_reportes_servicio(db: Annotated[AsyncSession, Depends(get_db)]) -> Repor
     repositorio_reportes_persona = PersonaReporteRepositorio(db)
     repositorio_reportes_usuario = UsuarioRetornoReporteRepositorio(db)
     repositorio_reportes_grupo =  GrupoReportoReporteRepositorio(db)
+    repositorio_registro_retorno = RegistroRetornoRepositorio(db)
+    repositorio_registro_retorno_grupo = RegistroRetornoGrupoRepositorio(db)
+
     return ReportesService(repositorio_colonia =  repositorio_reportes_colonia, 
                            repositorio_usuario = repositorio_reportes_usuario, repositorio_grupo = repositorio_reportes_grupo, 
-                           repositorio_persona = repositorio_reportes_persona)
+                           repositorio_persona = repositorio_reportes_persona, repositorio_registro_retorno=repositorio_registro_retorno,
+                           repositorio_registro_retorno_grupo = repositorio_registro_retorno_grupo)
 
 
 router = APIRouter()

--- a/app/reportes/services/reportes_service.py
+++ b/app/reportes/services/reportes_service.py
@@ -21,8 +21,10 @@ from app.reportes.repositories.grupo_retorno_reporte_repositorio import GrupoRep
 from app.reportes.repositories.persona_reporte_repositorio import PersonaReporteRepositorio
 from app.reportes.repositories.usuario_retorno_reporte_repositorio import UsuarioRetornoReporteRepositorio
 from app.reportes.utils.pdf_utils import render_to_pdf
-from app.retornos.excepciones.registro_retorno_excepciones import NoHayColonias, RetornoNoExistente
+from app.retornos.excepciones.registro_retorno_excepciones import NoHayColonias, NoHayRegistrosColoniaRetorno, NoHayRegistrosRetorno, RetornoNoExistente
 from app.retornos.modelos.retorno_grupo_usuario_modelo import Edades
+from app.retornos.repositorios.registro_retorno_grupo_repositorio import RegistroRetornoGrupoRepositorio
+from app.retornos.repositorios.registro_retorno_repositorio import RegistroRetornoRepositorio
 from app.usuarios.models.usuario import Genero
 
 logging.basicConfig(
@@ -34,11 +36,13 @@ logger = logging.getLogger(__name__)
 templates = Jinja2Templates(directory="app/reportes/templates")
 
 class ReportesService:
-    def __init__(self, repositorio_colonia: ColoniaReporteRepositorio, repositorio_usuario: UsuarioRetornoReporteRepositorio, repositorio_grupo: GrupoReportoReporteRepositorio, repositorio_persona: PersonaReporteRepositorio):
+    def __init__(self, repositorio_colonia: ColoniaReporteRepositorio, repositorio_usuario: UsuarioRetornoReporteRepositorio, repositorio_grupo: GrupoReportoReporteRepositorio, repositorio_persona: PersonaReporteRepositorio, repositorio_registro_retorno: RegistroRetornoRepositorio, repositorio_registro_retorno_grupo: RegistroRetornoGrupoRepositorio):
         self.repositorio_colonia = repositorio_colonia
         self.repositorio_usuario = repositorio_usuario
         self.repositorio_grupo = repositorio_grupo
         self.repositorio_persona = repositorio_persona
+        self.repositorio_registro_retorno = repositorio_registro_retorno
+        self.repositorio_registro_retorno_grupo = repositorio_registro_retorno_grupo
 
     async def generar_reporte_asistencia_retorno_colonia(self, request: Request, cod_colonia:int, cod_retorno:int):
        
@@ -48,6 +52,17 @@ class ReportesService:
         colonia = await self.repositorio_colonia.obtener_colonia(cod_colonia)
         if colonia is None:
             raise ColoniaNoExistente(cod_colonia)
+        
+        flag_registros_individuales = await self.repositorio_registro_retorno.hay_registros_retorno_colonia(cod_retorno,cod_colonia)
+        flag_rgistros_grupales = await self.repositorio_registro_retorno_grupo.hay_registros_retorno_colonia(cod_retorno,cod_colonia)
+
+        logger.info(f"Hay registros grupales: {flag_rgistros_grupales}")
+        logger.info(f"Hay registos individuales : {flag_registros_individuales}")
+
+        if not flag_registros_individuales and not flag_rgistros_grupales:
+            raise NoHayRegistrosColoniaRetorno(cod_retorno,cod_colonia)
+        
+
         lider_colonia = await self.repositorio_colonia.obtener_lider_colonia(cod_colonia)
         colonia = await self.repositorio_colonia.obtener_colonia(cod_colonia)
         retorno = await self.repositorio_colonia.obtener_retorno(cod_retorno)
@@ -135,6 +150,15 @@ class ReportesService:
         colonias = list(await self.repositorio_colonia.obtener_colonias())
         if colonias is None or len(colonias) == 0:
             raise NoHayColonias()
+        
+        flag_registros_individuales = await self.repositorio_registro_retorno.hay_registros_retorno(cod_retorno)
+        flag_rgistros_grupales = await self.repositorio_registro_retorno_grupo.hay_registros_retorno(cod_retorno)
+
+        logger.info(f"Hay registros grupales: {flag_rgistros_grupales}")
+        logger.info(f"Hay registos individuales : {flag_registros_individuales}")
+
+        if not flag_registros_individuales and not flag_rgistros_grupales:
+            raise NoHayRegistrosRetorno(cod_retorno)
         
         asistencia_colonia = []
         for colonia in colonias:

--- a/app/retornos/excepciones/registro_retorno_excepciones.py
+++ b/app/retornos/excepciones/registro_retorno_excepciones.py
@@ -13,7 +13,19 @@ class RetornoNoExistente(HTTPException):
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"El retorno con código {retorno_id} no existe."
         )
+class NoHayRegistrosColoniaRetorno(HTTPException):
+    def __init__(self, retorno_id: int, colonia_id):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"La colonia {colonia_id} no tiene registos en el retorno {retorno_id}."
+        )
 
+class NoHayRegistrosRetorno(HTTPException):
+    def __init__(self, retorno_id: int):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No hay registos en el retorno {retorno_id}."
+        )        
 class NoHayColonias(HTTPException):
     def __init__(self):
         super().__init__(

--- a/app/retornos/repositorios/registro_retorno_grupo_repositorio.py
+++ b/app/retornos/repositorios/registro_retorno_grupo_repositorio.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.retornos.modelos.grupo_retorno_modelo import GrupoRetorno
 from app.retornos.modelos.registro_retorno_grupo_modelo import RegistroRetornoGrupo
 from app.retornos.esquemas.registro_retorno_grupo_esquema import RegistroRetornoGrupoCrear
+from app.usuarios.models.usuario import Usuario
 
 
 class RegistroRetornoGrupoRepositorio:
@@ -77,3 +78,33 @@ class RegistroRetornoGrupoRepositorio:
         await self.db.commit()
         await self.db.refresh(registro)
         return registro
+    
+    async def hay_registros_retorno_colonia(self, cod_retorno:int, cod_colonia:int) -> bool:
+        """
+         Consulta si hay registros grupales en cod_retorno de la colonia cod_colonia
+         retorna:
+            True: Hay registros 
+            False: No hay registros
+        """
+        stmt = select(RegistroRetornoGrupo).join(
+                GrupoRetorno,
+                GrupoRetorno.gr_codigo == RegistroRetornoGrupo.cod_grupo
+            ).join(Usuario,
+                   Usuario.us_codigo == GrupoRetorno.us_codigo_lider).where(
+                Usuario.co_codigo == cod_colonia,
+                RegistroRetornoGrupo.retorno == cod_retorno
+            )
+        resultado = (await self.db.execute(stmt)).first()
+        return resultado is not None
+    async def hay_registros_retorno(self, cod_retorno:int)-> bool:
+        """
+         Consulta si hay registros grupales  en cod_retorno
+         retorna:
+            True: Hay registros 
+            False: No hay registros
+        """
+        stmt = select(RegistroRetornoGrupo).where(
+                RegistroRetornoGrupo.retorno == cod_retorno
+            )
+        resultado = (await self.db.execute(stmt)).first()
+        return resultado is not None

--- a/app/retornos/repositorios/registro_retorno_repositorio.py
+++ b/app/retornos/repositorios/registro_retorno_repositorio.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.retornos.esquemas.registro_retorno_esquema import RegistroRetornoCrear, RegistroRetornoEditar, RegistroRetornoDarseDeBaja, RegistroRetornoRespuesta
 from app.retornos.modelos.registro_retorno_modelo import RegistroRetorno
+from app.usuarios.models.usuario import Usuario
 
 class RegistroRetornoRepositorio:
     def __init__(self, db: AsyncSession):
@@ -82,3 +83,32 @@ class RegistroRetornoRepositorio:
         )
         resultado = await self.db.execute(query)
         return resultado.scalars().all()
+    
+    async def hay_registros_retorno_colonia(self, cod_retorno:int, cod_colonia:int) -> bool:
+        """
+         Consulta si hay registros en cod_retorno de la colonia cod_colonia
+         retorna:
+            True: Hay registros 
+            False: No hay registros
+        """
+        stmt = select(RegistroRetorno).join(Usuario,
+                   Usuario.us_codigo == RegistroRetorno.usuario).where(
+                Usuario.co_codigo == cod_colonia,
+                RegistroRetorno.retorno == cod_retorno
+            )
+        resultado = (await self.db.execute(stmt)).first()
+        return resultado is not None
+
+    async def hay_registros_retorno(self, cod_retorno:int)-> bool:
+        """
+         Consulta si hay registros en cod_retorno
+         retorna:
+            True: Hay registros 
+            False: No hay registros
+        """
+        stmt = select(RegistroRetorno).where(
+                RegistroRetorno.retorno == cod_retorno
+            )
+        resultado = (await self.db.execute(stmt)).first()
+        return resultado is not None
+


### PR DESCRIPTION
## Descripción del Cambio

En esta PR se soluciona el error 500 al generar reporte general de un retorno sin registros. 

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [x] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%?
- [x] ¿Las validaciones de negocio (Documento > 0, Celular 10 dígitos, etc.) están implementadas?

## ¿Cómo probar este cambio?
**Backend:**
1. Levantar con Docker.
2. Probar en postman:
- crear un retorno 
- generar reporte de asistencia general para el retorno creado
resultado esperado: 
error: 404
{
    "detail": "No hay registos al retorno 2."
}
