### PR TITLE
Feat/notificacion miembro eliminado grupo retorno

### DIFF
--- a/app/notificaciones/events/events.py
+++ b/app/notificaciones/events/events.py
@@ -18,6 +18,9 @@ class TipoEvento(Enum):
     ELIMINAR_GRUPO_RETORNO = "eliminar_grupo_retorno"
 
     DARSE_BAJA_RETORNO = "darse_baja_retorno"
+    SOLICITAR_PARENTESCO = "solicitar_parentesco"
+    ACEPTAR_PARENTESCO = "aceptar_parentesco"
+    RECHAZAR_PARENTESCO = "rechazar_parentesco"
 
 
 class MapeoEventosIds:
@@ -39,7 +42,10 @@ class MapeoEventosIds:
         TipoEvento.REGISTRO_GRUPO_RETORNO: 8,  # "Registro de grupo a retorno"
         TipoEvento.ACTUALIZACION_REGISTRO_GRUPO: 9,  # "Edición de registro de grupo"
         TipoEvento.DESACTIVAR_COLONIA: 10,  # "Desactivación de colonia"
-        TipoEvento.CREAR_SOLICITUD_INGRESO_COLONIA: 11
+        TipoEvento.CREAR_SOLICITUD_INGRESO_COLONIA: 11,
+        TipoEvento.SOLICITAR_PARENTESCO: 12,
+        TipoEvento.ACEPTAR_PARENTESCO: 13,
+        TipoEvento.RECHAZAR_PARENTESCO: 14
     }
     
     @classmethod
@@ -180,3 +186,37 @@ class EventoSolicitarIngresoColonia(EventoBase):
         nombre_completo = f"{nombre_usuario} {apellido_usuario}".strip()
         ubicacion = self.datos.get("colonia_ciudad") or self.datos.get("colonia_pais") or "la colonia"
         self.mensaje = f"El usuario {nombre_completo} solicita ingresar a la colonia {ubicacion}."
+
+
+class EventoSolicitarParentesco(EventoBase):
+    def __init__(self, datos, receptores):
+        super().__init__(TipoEvento.SOLICITAR_PARENTESCO, datos, receptores)
+
+    def construir_mensaje(self) -> str:
+        nombre_usuario = self.datos.get("nombre_usuario", "")
+        apellido_usuario = self.datos.get("apellido_usuario", "")
+        nombre_completo = f"{nombre_usuario} {apellido_usuario}".strip()
+        parentesco = self.datos.get("parentesco", "")
+        self.mensaje = f"El usuario {nombre_completo} solicita establecer parentesco {parentesco} contigo."
+
+class EventoAceptarParentesco(EventoBase):
+    def __init__(self, datos, receptores):
+        super().__init__(TipoEvento.ACEPTAR_PARENTESCO, datos, receptores)
+
+    def construir_mensaje(self) -> str:
+        nombre_usuario = self.datos.get("nombre_usuario", "")
+        apellido_usuario = self.datos.get("apellido_usuario", "")
+        nombre_completo = f"{nombre_usuario} {apellido_usuario}".strip()
+        parentesco = self.datos.get("parentesco", "")
+        self.mensaje = f"El usuario {nombre_completo} ha aceptado establecer parentesco {parentesco} contigo."
+
+class EventoRechazarParentesco(EventoBase):
+    def __init__(self, datos, receptores):
+        super().__init__(TipoEvento.RECHAZAR_PARENTESCO, datos, receptores)
+
+    def construir_mensaje(self) -> str:
+        nombre_usuario = self.datos.get("nombre_usuario", "")
+        apellido_usuario = self.datos.get("apellido_usuario", "")
+        nombre_completo = f"{nombre_usuario} {apellido_usuario}".strip()
+        parentesco = self.datos.get("parentesco", "")
+        self.mensaje = f"El usuario {nombre_completo} ha rechazado establecer parentesco {parentesco} contigo."

--- a/app/notificaciones/events/events.py
+++ b/app/notificaciones/events/events.py
@@ -21,6 +21,7 @@ class TipoEvento(Enum):
     SOLICITAR_PARENTESCO = "solicitar_parentesco"
     ACEPTAR_PARENTESCO = "aceptar_parentesco"
     RECHAZAR_PARENTESCO = "rechazar_parentesco"
+    ELIMINAR_MIEMBRO_GRUPO_RETORNO = "eliminar_miembro_grupo_retorno"
 
 
 class MapeoEventosIds:
@@ -45,7 +46,8 @@ class MapeoEventosIds:
         TipoEvento.CREAR_SOLICITUD_INGRESO_COLONIA: 11,
         TipoEvento.SOLICITAR_PARENTESCO: 12,
         TipoEvento.ACEPTAR_PARENTESCO: 13,
-        TipoEvento.RECHAZAR_PARENTESCO: 14
+        TipoEvento.RECHAZAR_PARENTESCO: 14,
+        TipoEvento.ELIMINAR_MIEMBRO_GRUPO_RETORNO: 15
     }
     
     @classmethod
@@ -220,3 +222,10 @@ class EventoRechazarParentesco(EventoBase):
         nombre_completo = f"{nombre_usuario} {apellido_usuario}".strip()
         parentesco = self.datos.get("parentesco", "")
         self.mensaje = f"El usuario {nombre_completo} ha rechazado establecer parentesco {parentesco} contigo."
+
+class EventoEliminarMiembroGrupoRetorno(EventoBase):
+    def __init__(self, datos, receptores):
+        super().__init__(TipoEvento.ELIMINAR_MIEMBRO_GRUPO_RETORNO, datos, receptores)
+
+    def construir_mensaje(self) -> str:
+        self.mensaje = f"Haz sido eliminado de tu grupo de retorno."

--- a/app/notificaciones/events/patron_observer.py
+++ b/app/notificaciones/events/patron_observer.py
@@ -23,7 +23,8 @@ from app.notificaciones.events.events import (
     EventoDarseBajaRetorno,
     EventoSolicitarParentesco,
     EventoAceptarParentesco,
-    EventoRechazarParentesco
+    EventoRechazarParentesco,
+    EventoEliminarMiembroGrupoRetorno
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
@@ -54,7 +55,8 @@ class FabricaEventos:
         TipoEvento.CREAR_SOLICITUD_INGRESO_COLONIA: EventoSolicitarIngresoColonia,
         TipoEvento.SOLICITAR_PARENTESCO: EventoSolicitarParentesco,
         TipoEvento.ACEPTAR_PARENTESCO: EventoAceptarParentesco,
-        TipoEvento.RECHAZAR_PARENTESCO: EventoRechazarParentesco
+        TipoEvento.RECHAZAR_PARENTESCO: EventoRechazarParentesco,
+        TipoEvento.ELIMINAR_MIEMBRO_GRUPO_RETORNO: EventoEliminarMiembroGrupoRetorno,
     }
     
     @classmethod

--- a/app/notificaciones/events/patron_observer.py
+++ b/app/notificaciones/events/patron_observer.py
@@ -20,7 +20,10 @@ from app.notificaciones.events.events import (
     EventoActualizacionRegistroGrupo,
     EventoDarseBajaGrupo,
     EventoEliminarGrupoRetorno,
-    EventoDarseBajaRetorno
+    EventoDarseBajaRetorno,
+    EventoSolicitarParentesco,
+    EventoAceptarParentesco,
+    EventoRechazarParentesco
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
@@ -48,7 +51,10 @@ class FabricaEventos:
         TipoEvento.DARSE_BAJA_GRUPO: EventoDarseBajaGrupo,
         TipoEvento.ELIMINAR_GRUPO_RETORNO: EventoEliminarGrupoRetorno,
         TipoEvento.DARSE_BAJA_RETORNO: EventoDarseBajaRetorno,
-        TipoEvento.CREAR_SOLICITUD_INGRESO_COLONIA: EventoSolicitarIngresoColonia
+        TipoEvento.CREAR_SOLICITUD_INGRESO_COLONIA: EventoSolicitarIngresoColonia,
+        TipoEvento.SOLICITAR_PARENTESCO: EventoSolicitarParentesco,
+        TipoEvento.ACEPTAR_PARENTESCO: EventoAceptarParentesco,
+        TipoEvento.RECHAZAR_PARENTESCO: EventoRechazarParentesco
     }
     
     @classmethod

--- a/app/retornos/api/v1/endpoints/retorno_router.py
+++ b/app/retornos/api/v1/endpoints/retorno_router.py
@@ -65,13 +65,14 @@ def obtener_registro_retorno_servicio(db: Annotated[AsyncSession, Depends(get_db
 def obtener_registro_retorno_grupo_servicio(db: Annotated[AsyncSession, Depends(get_db)]):
     repositorio_registro_grupo = RegistroRetornoGrupoRepositorio(db)
     repositorio_grupo = GrupoRetornoRepositorio(db)
+    repositorio_solicitudes = SolicitudGrupoRetornoRepositorio(db)
     repositorio_retorno = RetornoRepository(db)
     repositorio_usuario_grupo = RetornoGrupoUsuarioRepositorio(db)
     repositorio_persona = PersonaRepositorio(db) # Instanciar PersonaRepositorio
     repositorio_notificacion = NotificacionRepository(db)
     servicio_notificaciones = NotificacionCrearService(repositorio_notificacion)
     return RegistroRetornoGrupoServicio(
-        repositorio_registro_grupo, repositorio_grupo, repositorio_retorno, repositorio_usuario_grupo, repositorio_persona, servicio_notificaciones
+        repositorio_registro_grupo, repositorio_grupo, repositorio_retorno, repositorio_usuario_grupo, repositorio_persona, servicio_notificaciones, repositorio_solicitudes
     )
 
 def obtener_grupo_retorno_servicio(db: Annotated[AsyncSession, Depends(get_db)]):

--- a/app/retornos/servicios/grupo_retorno_servicio.py
+++ b/app/retornos/servicios/grupo_retorno_servicio.py
@@ -22,6 +22,7 @@ from app.usuarios.models.usuario import Usuario # Para el tipo de retorno del l√
 from fastapi import HTTPException, status
 from app.retornos.modelos.solicitud_grupo_retorno_modelo import SolicitudGrupoRetorno
 from app.retornos.esquemas.solicitud_grupo_retorno_esquema import SolicitudGrupoRetornoEstado
+
 class GrupoRetornoServicio:
     def __init__(self, repositorio_retorno: RetornoRepository = None, repositorio_grupos: GrupoRetornoRepositorio = None, repositorio_solicitudes: SolicitudGrupoRetornoRepositorio = None, repositorio_usuario_grupo: RetornoGrupoUsuarioRepositorio = None, repositorio_usuario: UsuarioRepositorio = None, repositorio_registro_individual: RegistroRetornoRepositorio = None, repositorio_registro_grupo: RegistroRetornoGrupoRepositorio = None,  servicio_notificaciones: NotificacionCrearService = None): # type: ignore
         self.repositorio_retorno = repositorio_retorno
@@ -264,6 +265,12 @@ class GrupoRetornoServicio:
         await self._validar_usuario_existente(us_codigo)
         await self._validar_si_usuario_es_miembro(us_codigo, gr_codigo)
         await self._validar_si_usuario_es_lider(us_codigo, gr_codigo)
+        evento = EventoBase(
+            tipo_evento=TipoEvento.ELIMINAR_MIEMBRO_GRUPO_RETORNO,
+            receptores=[us_codigo],
+            datos=None
+        )
+        await self.publicador.notificar(evento=evento)
         return await self.repositorio_usuario_grupo.remover_miembro_de_grupo_retorno(us_codigo, gr_codigo)
 
     

--- a/app/retornos/servicios/registro_retorno_grupo_servicio.py
+++ b/app/retornos/servicios/registro_retorno_grupo_servicio.py
@@ -29,14 +29,16 @@ class RegistroRetornoGrupoServicio:
         repositorio_grupo: GrupoRetornoRepositorio,
         repositorio_retorno: RetornoRepository,
         repositorio_usuario_grupo: RetornoGrupoUsuarioRepositorio,
-        repositorio_persona: PersonaRepositorio, # Nuevo repositorio para personas
-        servicio_notificaciones: NotificacionCrearService
+        repositorio_persona: PersonaRepositorio, 
+        servicio_notificaciones: NotificacionCrearService,
+        repositorio_solicitudes: SolicitudGrupoRetornoRepositorio = None
     ):
         self.repositorio_registro_grupo = repositorio_registro_grupo
         self.repositorio_grupo = repositorio_grupo
         self.repositorio_retorno = repositorio_retorno
         self.repositorio_usuario_grupo = repositorio_usuario_grupo
-        self.repositorio_persona = repositorio_persona # Asignar el nuevo repositorio
+        self.repositorio_persona = repositorio_persona 
+        self.repositorio_solicitudes = repositorio_solicitudes
         self.publicador = Publicador(servicio_notificaciones)
     def _validar_retorno(self, retorno, codigo_retorno, accion):
         if not retorno:

--- a/app/usuarios/api/v1/usuario_router.py
+++ b/app/usuarios/api/v1/usuario_router.py
@@ -10,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import get_settings
 from app.core.database import get_db
+from app.notificaciones.repositories.notificacion_repositorio import NotificacionRepository
+from app.notificaciones.services.notificacion_crear_service import NotificacionCrearService
 from app.usuarios.auth_dependencies import get_current_user, require_roles
 from app.usuarios.models.usuario import Usuario
 from app.usuarios.repository.parentesco_repositorio import ParentescoRepositorio
@@ -63,7 +65,9 @@ def get_usuario_servicio(db: Annotated[AsyncSession, Depends(get_db)]) -> Usuari
     """
     repositorio = UsuarioRepositorio(db)
     repositorio_parentesco = ParentescoRepositorio(db)
-    return UsuarioServicio(repositorio, repositorio_parentesco)
+    repositorio_notificacion = NotificacionRepository(db)
+    servicio_notificaciones = NotificacionCrearService(repositorio_notificacion)
+    return UsuarioServicio(repositorio, repositorio_parentesco, servicio_notificaciones)
 
 
 @router.post(

--- a/app/usuarios/services/usuario_servicio.py
+++ b/app/usuarios/services/usuario_servicio.py
@@ -7,6 +7,9 @@ de datos requeridas antes de interactuar con la capa de repositorio.
 from passlib.context import CryptContext
 from sqlalchemy import select
 
+from app.notificaciones.events.events import EventoBase, TipoEvento
+from app.notificaciones.events.patron_observer import Publicador
+from app.notificaciones.services.notificacion_crear_service import NotificacionCrearService
 from app.usuarios.models.parentesco import EstadoSolicitudParentesco
 from app.usuarios.models.usuario import Usuario
 from app.usuarios.repository.parentesco_repositorio import ParentescoRepositorio
@@ -41,7 +44,7 @@ class UsuarioServicio:
     Servicio para gestionar la lógica de negocio de los usuarios.
     """
 
-    def __init__(self, repositorio: UsuarioRepositorio, repositorio_parentesco: ParentescoRepositorio | None = None) -> None:
+    def __init__(self, repositorio: UsuarioRepositorio, repositorio_parentesco: ParentescoRepositorio | None = None, servicio_notificaciones: NotificacionCrearService | None = None) -> None:
         """
         Inicializa el servicio con un repositorio de usuarios.
 
@@ -51,6 +54,7 @@ class UsuarioServicio:
         """
         self.repositorio = repositorio
         self.repositorio_parentesco = repositorio_parentesco
+        self.publicador = Publicador(servicio_notificaciones)
 
     async def registrar(self, schema: UsuarioCrear) -> Usuario:
         """
@@ -214,6 +218,14 @@ class UsuarioServicio:
         if solicitud.estado != EstadoSolicitudParentesco.pendiente:
             raise ValueError("Solo se pueden aceptar solicitudes que estén en estado pendiente.")
         parentesco = await self.repositorio_parentesco.actualizar_estado_parentesco(codigo_solicitud, EstadoSolicitudParentesco.aceptada)
+        
+        solicitud_detallada = await self.repositorio_parentesco.obtener_parentesco_por_id_detallado(codigo_solicitud)
+        evento = EventoBase(
+            tipo_evento=TipoEvento.ACEPTAR_PARENTESCO,
+            datos={"parentesco": solicitud_detallada.tipo_parentesco.value, "nombre_usuario": solicitud_detallada.destinatario.us_nombre, "apellido_usuario": solicitud_detallada.destinatario.us_apellido},
+            receptores=[solicitud_detallada.codigo_solicitante])
+        await self.publicador.notificar(
+            evento=evento)
         return ParentescoRespuesta(
             codigo=parentesco.codigo,
             codigo_solicitante=parentesco.codigo_solicitante,
@@ -231,6 +243,14 @@ class UsuarioServicio:
         if solicitud.estado != EstadoSolicitudParentesco.pendiente:
             raise ValueError("Solo se pueden rechazar solicitudes que estén en estado pendiente.")
         parentesco = await self.repositorio_parentesco.actualizar_estado_parentesco(codigo_solicitud, EstadoSolicitudParentesco.rechazada)
+        
+        solicitud_detallada = await self.repositorio_parentesco.obtener_parentesco_por_id_detallado(codigo_solicitud)
+        evento = EventoBase(
+            tipo_evento=TipoEvento.RECHAZAR_PARENTESCO,
+            datos={"parentesco": solicitud_detallada.tipo_parentesco.value, "nombre_usuario": solicitud_detallada.destinatario.us_nombre, "apellido_usuario": solicitud_detallada.destinatario.us_apellido},
+            receptores=[solicitud_detallada.codigo_solicitante])
+        await self.publicador.notificar(
+            evento=evento)
         return ParentescoRespuesta(
             codigo=parentesco.codigo,
             codigo_solicitante=parentesco.codigo_solicitante,
@@ -267,6 +287,13 @@ class UsuarioServicio:
             raise ValueError("Ya existe una solicitud de parentesco pendiente entre estos usuarios.")
 
         solicitud_parentesco =  await self.repositorio_parentesco.solicitar_parentesco(parentesco_crear)
+        solicitud_detallada = await self.repositorio_parentesco.obtener_parentesco_por_id_detallado(solicitud_parentesco.codigo)
+        evento = EventoBase(
+            tipo_evento=TipoEvento.SOLICITAR_PARENTESCO,
+            datos={"parentesco": solicitud_detallada.tipo_parentesco.value, "nombre_usuario": solicitud_detallada.solicitante.us_nombre, "apellido_usuario": solicitud_detallada.solicitante.us_apellido},
+            receptores=[solicitud_detallada.codigo_destinatario])
+        await self.publicador.notificar(
+            evento=evento)
         return ParentescoRespuesta(
             codigo=solicitud_parentesco.codigo,
             codigo_solicitante=solicitud_parentesco.codigo_solicitante,

--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -269,7 +269,7 @@ async def seed_data() -> None:
             
             grupos = []
             # Grupo 1 liderado por María (usuario 2)
-            grupo1 = GrupoRetorno(us_codigo_lider=usuarios[1].us_codigo)
+            grupo1 = GrupoRetorno(us_codigo_lider=usuarios[2].us_codigo)
             db.add(grupo1)
             grupos.append(grupo1)
             
@@ -342,9 +342,17 @@ async def seed_data() -> None:
             rgu1 = RetornoGrupoUsuario(us_codigo=usuarios[1].us_codigo, gr_codigo=grupos[0].gr_codigo)
             db.add(rgu1)
 
+            # asociar a María (lider) al grupo 1
+            rgu1_lider = RetornoGrupoUsuario(us_codigo=usuarios[2].us_codigo, gr_codigo=grupos[0].gr_codigo)
+            db.add(rgu1_lider)
+
             # Grupo 2: Ana (lider)
             rgu2 = RetornoGrupoUsuario(us_codigo=usuarios[3].us_codigo, gr_codigo=grupos[1].gr_codigo)
             db.add(rgu2)
+
+            # asociar a Ana (lider) al grupo 2
+            rgu2_lider = RetornoGrupoUsuario(us_codigo=usuarios[4].us_codigo, gr_codigo=grupos[1].gr_codigo)
+            db.add(rgu2_lider)
             await db.flush()
             logger.info("✓ Usuarios asociados a grupos de retorno")
 

--- a/scripts/seed_eventos.py
+++ b/scripts/seed_eventos.py
@@ -74,6 +74,10 @@ EVENTOS = [
         "ev_nombre": "Rechazo de parentesco",
         "ev_descripcion": "Se genera cuando un usuario rechaza una solicitud de parentesco"
     },
+    {
+        "ev_nombre": "Eliminación de miembro de grupo de retorno",
+        "ev_descripcion": "Se genera cuando un usuario es eliminado de un grupo de retorno por el líder del grupo."
+    }
 ]
 
 

--- a/scripts/seed_eventos.py
+++ b/scripts/seed_eventos.py
@@ -62,6 +62,18 @@ EVENTOS = [
         "ev_nombre": "Solicitud ingreso a colonia",
         "ev_descripcion": "Se genera cuando un usuario crea una solicitud de ingreso a una colonia"
     },
+    {
+        "ev_nombre": "Solicitud de parentesco",
+        "ev_descripcion": "Se genera cuando un usuario crea una solicitud de parentesco"
+    },
+    {
+        "ev_nombre": "Aceptación de parentesco",
+        "ev_descripcion": "Se genera cuando un usuario acepta una solicitud de parentesco"
+    },
+    {
+        "ev_nombre": "Rechazo de parentesco",
+        "ev_descripcion": "Se genera cuando un usuario rechaza una solicitud de parentesco"
+    },
 ]
 
 

--- a/tests/retornos/test_notificaciones_retornos.py
+++ b/tests/retornos/test_notificaciones_retornos.py
@@ -8,6 +8,7 @@ Cubre los siguientes escenarios:
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch, call
+from app.retornos.servicios.grupo_retorno_servicio import GrupoRetornoServicio
 from app.retornos.servicios.registro_retorno_servicio import RegistroRetornoServicio
 from app.retornos.servicios.registro_retorno_grupo_servicio import RegistroRetornoGrupoServicio
 from app.notificaciones.events.events import TipoEvento, EventoBase
@@ -52,8 +53,16 @@ def mock_repositorio_usuario_grupo():
     repositorio.contar_miembros_adicionales = AsyncMock()
     repositorio.obtener_miembros_por_grupo = AsyncMock()
     repositorio.asociar_usuario_a_grupo_retorno = AsyncMock()
+    repositorio.existe_usuario_en_grupo_para_retorno = AsyncMock()
+    repositorio.remover_miembro_de_grupo_retorno = AsyncMock()
     return repositorio
 
+@pytest.fixture
+def mock_repositorio_usuario():
+    """Mock para el repositorio de usuarios."""
+    repositorio = MagicMock()
+    repositorio.obtener_usuario_por_id = AsyncMock()
+    return repositorio
 
 @pytest.fixture
 def mock_repositorio_persona():
@@ -73,6 +82,12 @@ def mock_repositorio_registro_grupo():
     repositorio.editar_registro_grupo_retorno = AsyncMock()
     return repositorio
 
+@pytest.fixture 
+def mock_repositorio_solicitudes():
+    """Mock para el repositorio de solicitudes a un grupo de retorno."""
+    repositorio = MagicMock()
+    repositorio.expirar_solicitudes_pendientes_por_grupo_retorno = AsyncMock()
+    return repositorio
 
 @pytest.fixture
 def mock_usuario_servicio():
@@ -109,7 +124,7 @@ def servicio_registro_retorno(mock_repositorio_registro_retorno, mock_repositori
 @pytest.fixture
 def servicio_registro_grupo(mock_repositorio_registro_grupo, mock_repositorio_grupo_retorno,
                             mock_repositorio_retorno, mock_repositorio_usuario_grupo,
-                            mock_repositorio_persona, mock_servicio_notificaciones):
+                            mock_repositorio_persona, mock_servicio_notificaciones, mock_repositorio_solicitudes):
     """Crea una instancia del servicio de registro de grupo de retorno con mocks."""
     servicio = RegistroRetornoGrupoServicio(
         mock_repositorio_registro_grupo,
@@ -117,9 +132,25 @@ def servicio_registro_grupo(mock_repositorio_registro_grupo, mock_repositorio_gr
         mock_repositorio_retorno,
         mock_repositorio_usuario_grupo,
         mock_repositorio_persona,
-        mock_servicio_notificaciones
+        mock_servicio_notificaciones,
+        mock_repositorio_solicitudes
+
     )
-    # El publicador se crea automáticamente en el __init__
+    
+    servicio.publicador = MagicMock(spec=Publicador)
+    servicio.publicador.notificar = AsyncMock()
+    return servicio
+
+@pytest.fixture
+def grupo_retorno_servicio(mock_repositorio_grupo_retorno, mock_repositorio_usuario_grupo, mock_servicio_notificaciones, mock_repositorio_usuario):
+    """Crea una instancia del servicio de grupo de retorno con mocks."""
+    servicio = GrupoRetornoServicio(
+    repositorio_grupos=mock_repositorio_grupo_retorno,
+    repositorio_usuario_grupo=mock_repositorio_usuario_grupo,
+    servicio_notificaciones=mock_servicio_notificaciones,
+    repositorio_usuario=mock_repositorio_usuario
+    )
+
     servicio.publicador = MagicMock(spec=Publicador)
     servicio.publicador.notificar = AsyncMock()
     return servicio
@@ -152,26 +183,13 @@ def colonia_mock():
 def usuario_mock():
     """Mock de un usuario."""
     usuario = MagicMock()
-    usuario.us_codigo = 10
+    usuario.us_codigo = 11
     usuario.us_nombre = "Juan"
     usuario.us_apellido = "Pérez"
     usuario.co_codigo = 1
     usuario.us_documento = "12345678"
     usuario.colonia = MagicMock()
     return usuario
-
-@pytest.fixture
-def usuario_mock():
-    """Mock de un usuario."""
-    usuario = MagicMock()
-    usuario.us_codigo = 10
-    usuario.us_nombre = "Juan"
-    usuario.us_apellido = "Pérez"
-    usuario.co_codigo = 1
-    usuario.us_documento = "12345678"
-    usuario.colonia = MagicMock()
-    return usuario
-
 
 @pytest.fixture
 def retorno_mock():
@@ -226,7 +244,7 @@ def registro_grupo_retorno_mock(grupo_retorno_mock, retorno_mock):
 def usuarios_grupo():
     """Mock de usuarios en un grupo."""
     usuario1 = MagicMock()
-    usuario1.us_codigo = 10
+    usuario1.us_codigo = 11
     usuario2 = MagicMock()
     usuario2.us_codigo = 15
     return [usuario1, usuario2]
@@ -394,5 +412,48 @@ async def test_notificacion_actualizacion_registro_grupo(
     
     # Validar receptores (deben ser todos los miembros del grupo)
     assert evento.receptores == [usuario.us_codigo for usuario in usuarios_grupo]
+
+# ==================== PRUEBAS: ELIMINACIÓN DE MIEMBRO DE GRUPO DE RETORNO ====================
+
+@pytest.mark.asyncio
+async def test_notificacion_eliminacion_miembro_grupo_retorno(
+    grupo_retorno_servicio, mock_repositorio_usuario_grupo, mock_repositorio_grupo_retorno,
+    grupo_retorno_mock, usuario_mock, mock_repositorio_usuario
+):
+    """
+    Test: Cuando un miembro es eliminado de un grupo de retorno,
+    se genera una notificación para el miembro eliminado.
+    
+    Caso de uso: El miembro eliminado recibe notificación de "Has sido eliminado de tu grupo de retorno"
+    """
+    # Arrange
+    us_codigo = usuario_mock.us_codigo
+    gr_codigo = grupo_retorno_mock.gr_codigo
+
+    mock_repositorio_usuario_grupo.remover_miembro_de_grupo_retorno.return_value = True
+    mock_repositorio_grupo_retorno.obtener_grupo_por_id.return_value = grupo_retorno_mock
+    mock_repositorio_usuario_grupo.existe_usuario_en_grupo_para_retorno.return_value = True
+    mock_repositorio_usuario_grupo.remover_miembro_de_grupo_retorno.return_value = True
+    mock_repositorio_usuario.obtener_usuario_por_id.return_value = usuario_mock
+    
+    # Inyectar publicador
+    grupo_retorno_servicio.publicador = MagicMock(spec=Publicador)
+    grupo_retorno_servicio.publicador.notificar = AsyncMock()
+
+    # Act
+    resultado = await grupo_retorno_servicio.remover_miembro_de_grupo_retorno(us_codigo, gr_codigo)
+
+    # Assert - Verificar que se llamó al publicador
+    grupo_retorno_servicio.publicador.notificar.assert_called_once()
+    evento = grupo_retorno_servicio.publicador.notificar.call_args[1]["evento"]
+    
+    # Validar tipo de evento
+    assert evento.tipo_evento == TipoEvento.ELIMINAR_MIEMBRO_GRUPO_RETORNO
+    
+    # Validar datos del evento (puede ser None si no hay datos específicos)
+    assert evento.datos is None
+    
+    # Validar receptores (debe ser solo el miembro eliminado)
+    assert evento.receptores == [us_codigo]
 
 


### PR DESCRIPTION
## Descripción del Cambio

En ests PR se implementa la notificación cuando un usuario es eliminado del grupo de retorno por el lider del grupo. 

## Checklist de Autorevisión (Antes de asignar a QA)
- [x] ¿El código sigue el estándar **PEP 8 / ESLint/Prettier**?
- [x] ¿La nomenclatura es correcta (**snake_case** en Back(ES) / **camelCase** en Front(EN))?
- [x] ¿Los modelos y esquemas están dentro de su **módulo correspondiente**?
- [x] ¿Se incluyeron **pruebas unitarias** con cobertura mínima del 70%?
- [x] ¿Las validaciones de negocio (Documento > 0, Celular 10 dígitos, etc.) están implementadas?

## ¿Cómo probar este cambio?
**Backend:**
1. Levantar con Docker.
2. Probar en Swagger (`/docs`) con estos datos: 
- Con los datos semillas.
1. inicia sesion con con juan perez. cuyas credenciales son juan.perez@email.com usuario123, y cuyo codigo de usuario es 2.
2. eliminalo de su grupo de retorno, juan pertenece al grupo de retorno 1: /api/v1/grupoRetorno/grupo/usuario/eliminar-miembro
3. consulta sus notificaciones: /api/v1/notificaciones/usuario/{id_usuario}/no-leidas, debes encontrar la siguiente notificacion:
[
  {
    "codigo": 1,
    "mensaje": "Haz sido eliminado de tu grupo de retorno.",
    "codigo_receptor": 2,
    "evento": {
      "codigo": 15,
      "nombre": "Eliminación de miembro de grupo de retorno",
      "descripcion": "Se genera cuando un usuario es eliminado de un grupo de retorno por el lider del grupo"
    },
    "time_stamp": "2026-07-16T19:01:58.172140+00:00",
    "estado": "sin_leer"
  }
]

